### PR TITLE
Add comprehensive documentation to the rotating file sink

### DIFF
--- a/spdlog/src/sink/rotating_file_sink.rs
+++ b/spdlog/src/sink/rotating_file_sink.rs
@@ -21,8 +21,24 @@ use crate::{
 
 /// Rotation policies for [`RotatingFileSink`].
 ///
-/// For more information about rotating file sink and rotation policies, please
-/// refer to the documentation of [`RotatingFileSink`].
+/// Rotation policy defines when and how to split log messages into log files,
+/// during which new log files may be created and old log files may be deleted.
+/// Currently `spdlog` provides 3 different rotation policies:
+///
+/// - Rotate by file size, which is represented by the
+///   `RotationPolicy::FileSize` variant. Under this rotation policy, the sink
+///   rotates log messages when the size of the current log file exceeds a
+///   limit. The sink will then create a new log file for further log messages
+///   and may optionally delete the oldest log files depending on the maximum
+///   number of files allowed.
+/// - Rotate daily, which is represented by the `RotationPolicy::Daily` variant.
+///   Under this rotation policy, the sink automatically creates a new log file
+///   at a specified time point within a day. The oldest log files may be
+///   deleted, depending on the maximum number of allowed log files.
+/// - Rotate hourly, which is represented by the `RotationPolicy::Hourly`
+///   variant. Under this rotation policy, the sink automatically creates a new
+///   log file at a specified time point within each hour. The oldest log files
+///   may be deleted, depending on the maximum number of allowed log files.
 ///
 /// # Panics
 ///
@@ -94,50 +110,46 @@ struct RotatorTimePointInner {
 /// A sink with a collection of files as the target, rotating according to the
 /// rotation policy.
 ///
-/// # Overview
-///
 /// A service program that runs for a long time in an environment with limited
 /// hard disk space may continue to write messages to the log file and
 /// eventually run out of hard disk space. `RotatingFileSink` is designed for
-/// such a usage scenario. It periodically removes old log messages and files
-/// from disk to make sure the hard disk won't be filled up by log files.
+/// such a usage scenario. It splits log messages into one or more log files
+/// and may be configured to delete old log files automatically to save disk
+/// space. The operation that splits log messages into multiple log files and
+/// optionally creates and deletes log files is called a **rotation**. The
+/// **rotation policy** determines when and how log files are created or
+/// deleted, and how log messages are written to different log files.
 ///
-/// Each rotating file sink is created with a **base path** that points to a
-/// directory where log files will be managed. You can set the base path with
+/// # Parameters
+///
+/// A rotating file sink can be created with 3 parameters: the **base path**,
+/// the **maximum number of log files**, and the **rotation policy**.
+///
+/// ## The Base Path
+///
+/// Each rotating file sink requires a **base path** which serves as a template
+/// to form log file paths. You can set the base path with
 /// [`RotatingFileSinkBuilder::base_path`] when building a rotating file sink.
-/// The rotating file sink automatically creates new log files and deletes old
-/// log files under the base path. The operation that creates new log files and
-/// (optionally) deletes old log files is called a **rotation**. When and how to
-/// rotate is determined by two parameters: the maximum number of log files
-/// allowed under the base path and the **rotation policy**.
+/// Different rotation policy may use different file name patterns based on the
+/// base path. For more information about the base path, see the documentation
+/// of [`RotatingFileSinkBuilder::base_path`].
 ///
 /// # Maximum Number of Log Files
 ///
-/// This parameter defines the maximum number of log files allowed under the
-/// base path. You can set this parameter with
-/// [`RotatingFileSinkBuilder::max_files`] when building a rotating file sink.
-/// During a rotation, the sink won't delete old log files unless the number of
-/// log files under the base path exceeds this limit. Furthermore, setting this
-/// parameter to 0 indicates that no limits are applied and effectively prevents
-/// the sink from deleting any old log files.
+/// This parameter defines the maximum number of log files allowed on the disk.
+/// You can set this parameter with [`RotatingFileSinkBuilder::max_files`] when
+/// building a rotating file sink. During a rotation, the sink won't delete old
+/// log files unless the number of log files on the disk exceeds this
+/// limit. Furthermore, setting this parameter to 0 indicates that no limits are
+/// applied and effectively prevents the sink from deleting any old log files.
 ///
 /// # Rotation Policy
 ///
 /// [`RotationPolicy`] defines the different available rotation policies. You
 /// can set the rotation policy with
 /// [`RotatingFileSinkBuilder::rotation_policy`] when building a rotating file
-/// sink. Currently `spdlog` provides 3 different rotation policies:
-///
-/// - Rotate by file size, which is represented by the
-///   `RotationPolicy::FileSize` variant. Under this rotation policy, the sink
-///   won't rotate log files unless the size of the current log file exceeds a
-///   limit.
-/// - Rotate daily, which is represented by the `RotationPolicy::Daily` variant.
-///   Under this rotation policy, the sink automatically rotates log files at a
-///   specified time point within each consecutive day.
-/// - Rotate hourly, which is represented by the `RotationPolicy::Hourly`
-///   variant. Under this rotation policy, the sink automatically rotates log
-///   files at a specified time point within each consecutive hour.
+/// sink. For more information about different rotation policies, please refer
+/// to the documentation of [`RotationPolicy`].
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Existing documentation of the rotating file sink is too simple and incomprehensive. This PR improves its documentation.