### PR TITLE
Allow forking from existing loggers

### DIFF
--- a/spdlog/benches/compare_with_cpp_spdlog_async.rs
+++ b/spdlog/benches/compare_with_cpp_spdlog_async.rs
@@ -10,7 +10,12 @@ use test::black_box;
 use clap::Parser;
 use once_cell::sync::Lazy;
 
-use spdlog::{prelude::*, sink::*, Error, SendToChannelError, ThreadPool};
+use spdlog::{
+    error::{Error, SendToChannelError},
+    prelude::*,
+    sink::*,
+    ThreadPool,
+};
 
 required_multi_thread_feature!();
 

--- a/spdlog/benches/spdlog_rs.rs
+++ b/spdlog/benches/spdlog_rs.rs
@@ -9,7 +9,12 @@ use test::Bencher;
 
 use once_cell::sync::Lazy;
 
-use spdlog::{prelude::*, sink::*, Error, ErrorHandler, SendToChannelError, ThreadPool};
+use spdlog::{
+    error::{Error, ErrorHandler, SendToChannelError},
+    prelude::*,
+    sink::*,
+    ThreadPool,
+};
 
 required_multi_thread_feature!();
 

--- a/spdlog/src/error.rs
+++ b/spdlog/src/error.rs
@@ -9,6 +9,8 @@ use thiserror::Error;
 #[cfg(feature = "multi-thread")]
 use crate::{sink::Task, RecordOwned};
 
+pub use crate::env_level::EnvLevelError;
+
 /// The error type of this crate.
 #[derive(Error, Debug)]
 #[non_exhaustive]

--- a/spdlog/src/lib.rs
+++ b/spdlog/src/lib.rs
@@ -194,7 +194,7 @@
 #![warn(missing_docs)]
 
 mod env_level;
-mod error;
+pub mod error;
 pub mod formatter;
 mod level;
 #[cfg(feature = "log")]
@@ -215,8 +215,7 @@ mod test_utils;
 mod thread_pool;
 mod utils;
 
-pub use env_level::EnvLevelError;
-pub use error::*;
+pub use error::{Error, ErrorHandler, Result};
 pub use level::*;
 #[cfg(feature = "log")]
 pub use log_crate_proxy::*;
@@ -242,6 +241,7 @@ use std::{
 
 use cfg_if::cfg_if;
 
+use error::EnvLevelError;
 use sink::{
     Sink, {StdStream, StdStreamSink},
 };
@@ -523,16 +523,10 @@ pub fn set_default_logger(logger: Arc<Logger>) {
 ///
 ///   ```
 ///   # std::env::set_var("SPDLOG_RS_LEVEL", "network=Warn,network=Warn");
-///   let result = spdlog::init_env_level();
-///   # // TODO: commented out since `assert_matches` is currently unstable.
-///   # //       change to use `assert_matches` when it is stable.
-///   # // assert_matches!(result, Err(spdlog::EnvLevelError::ParseEnvVar(_)));
-///   if let Err(spdlog::EnvLevelError::ParseEnvVar(_)) = result {
-///       // expected
-///   } else {
-///       // unexpected
-///       assert!(false);
-///   }
+///   assert!(matches!(
+///       spdlog::init_env_level(),
+///       Err(spdlog::error::EnvLevelError::ParseEnvVar(_))
+///   ));
 ///   ```
 pub fn init_env_level() -> StdResult<bool, EnvLevelError> {
     init_env_level_from("SPDLOG_RS_LEVEL")

--- a/spdlog/src/logger.rs
+++ b/spdlog/src/logger.rs
@@ -4,10 +4,11 @@ use std::time::Duration;
 
 use crate::{
     env_level,
+    error::{BuildLoggerError, Error, ErrorHandler},
     periodic_worker::PeriodicWorker,
     sink::{Sink, Sinks},
     sync::*,
-    BuildLoggerError, Error, ErrorHandler, Level, LevelFilter, Record, Result,
+    Level, LevelFilter, Record, Result,
 };
 
 /// A logger structure.


### PR DESCRIPTION
Closes #13.

To avoid confusion with the semantics of `Arc::clone`, I have named the new methods as `fork_xxx`.

## Unsolved Questions

 - [ ] Not sure if `fn fork(self: &Arc<Self>) -> Result<Arc<Self>>` (no modifier, just fork as is) is also necessary to add.