### PR TITLE
use is-terminal instead of atty dep for RUSTSEC-2021-0145

### DIFF
--- a/spdlog/Cargo.toml
+++ b/spdlog/Cargo.toml
@@ -40,12 +40,12 @@ multi-thread = ["crossbeam"]
 [dependencies]
 arc-swap = "1.5.1"
 atomic = "0.5.1"
-atty = "0.2.14"
 cfg-if = "1.0.0"
 chrono = "0.4.22"
 crossbeam = { version = "0.8.2", optional = true }
 flexible-string = { version = "0.1.0", optional = true }
 if_chain = "1.0.2"
+is-terminal = "0.4"
 log = { version = "0.4", optional = true }
 once_cell = "1.16.0"
 spdlog-macros = { version = "0.1.0", path = "../spdlog-macros" }


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2021-0145 details an alignment/unsoundness issue in `atty`, which is solved with the smaller `is-terminal` crate.  This PR changes the dependency!

Tests pass locally - happy to iterate if there are things that could be factored/done better