### PR TITLE
Bump dependency `spin` to v0.9.8 for RUSTSEC-2023-0031

### DIFF
--- a/spdlog/Cargo.toml
+++ b/spdlog/Cargo.toml
@@ -49,7 +49,7 @@ is-terminal = "0.4"
 log = { version = "0.4", optional = true }
 once_cell = "1.16.0"
 spdlog-macros = { version = "0.1.0", path = "../spdlog-macros" }
-spin = "0.9.4"
+spin = "0.9.8"
 static_assertions = "1.1.0"
 thiserror = "1.0.37"
 


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html) | mvdnes/spin-rs#148