### PR TITLE
Fix `{tid}` incorrectly outputting TID of thread pool in `AsyncPoolSink`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+# TODO: Remove this in the next minor version (After `RecordOwned` is boxed in `SendToChannelErrorDropped`)
+large-error-threshold = 136

--- a/spdlog/src/error.rs
+++ b/spdlog/src/error.rs
@@ -174,6 +174,7 @@ pub enum SendToChannelError {
 #[non_exhaustive]
 pub enum SendToChannelErrorDropped {
     /// A `log` operation and a record are dropped.
+    // TODO: Box the `RecordOwned` in the next minor version, as it's a bit large.
     Record(RecordOwned),
     /// A `flush` operation is dropped.
     Flush,

--- a/spdlog/src/formatter/pattern_formatter/pattern/process_id.rs
+++ b/spdlog/src/formatter/pattern_formatter/pattern/process_id.rs
@@ -30,6 +30,9 @@ impl Pattern for ProcessId {
     }
 }
 
+// TODO: We can cache the PID someway to improve the performance, but remember
+// to test the case of process forking.
+
 #[cfg(target_family = "unix")]
 #[must_use]
 fn get_current_process_id() -> u64 {

--- a/spdlog/src/formatter/pattern_formatter/pattern/thread_id.rs
+++ b/spdlog/src/formatter/pattern_formatter/pattern/thread_id.rs
@@ -23,32 +23,10 @@ pub struct ThreadId;
 impl Pattern for ThreadId {
     fn format(
         &self,
-        _record: &Record,
+        record: &Record,
         dest: &mut StringBuf,
         _ctx: &mut PatternContext,
     ) -> crate::Result<()> {
-        let tid = get_current_thread_id();
-        write!(dest, "{}", tid).map_err(Error::FormatRecord)
+        write!(dest, "{}", record.tid()).map_err(Error::FormatRecord)
     }
-}
-
-#[cfg(target_os = "linux")]
-#[must_use]
-fn get_current_thread_id() -> u64 {
-    let tid = unsafe { libc::gettid() };
-    tid as u64
-}
-
-#[cfg(target_os = "macos")]
-#[must_use]
-fn get_current_thread_id() -> u64 {
-    let tid = unsafe { libc::pthread_self() };
-    tid as u64
-}
-
-#[cfg(target_os = "windows")]
-#[must_use]
-fn get_current_thread_id() -> u64 {
-    let tid = unsafe { winapi::um::processthreadsapi::GetCurrentThreadId() };
-    tid as u64
 }


### PR DESCRIPTION
Fixes #28, by getting TID during the build of each record and caching it in the thread local to improve performance.