### PR TITLE
Replace `gettid()` with `syscall(SYS_gettid)` for earlier glibc versions

### DIFF
--- a/spdlog/src/record.rs
+++ b/spdlog/src/record.rs
@@ -261,7 +261,11 @@ fn get_current_tid() -> u64 {
     #[cfg(target_os = "linux")]
     #[must_use]
     fn get_current_tid_inner() -> u64 {
-        let tid = unsafe { libc::gettid() };
+        // https://github.com/SpriteOvO/spdlog-rs/issues/31
+        //
+        // We don't use `gettid` since earlier glibc versions (before v2.30) did not
+        // provide a wrapper for this system call.
+        let tid = unsafe { libc::syscall(libc::SYS_gettid) };
         tid as u64
     }
 


### PR DESCRIPTION
Fixes #31.

Reference from [gettid() of Ubuntu manpage](https://manpages.ubuntu.com/manpages/focal/en/man2/gettid.2.html).

> Library  support  was added  in  glibc  2.30.  (Earlier glibc versions did not provide a wrapper for this system  call, necessitating the use of [syscall](https://manpages.ubuntu.com/manpages/focal/en/man2/syscall.2.html)(2).)