### PR TITLE
Replace `pthread_self` with `pthread_threadid_np` on macOS

### DIFF
--- a/spdlog/src/record.rs
+++ b/spdlog/src/record.rs
@@ -272,8 +272,9 @@ fn get_current_tid() -> u64 {
     #[cfg(target_os = "macos")]
     #[must_use]
     fn get_current_tid_inner() -> u64 {
-        let tid = unsafe { libc::pthread_self() };
-        tid as u64
+        let mut tid = 0;
+        unsafe { libc::pthread_threadid_np(0, &mut tid) };
+        tid
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
This PR changes the implementation of `fn get_current_tid()` on macOS.

The previous used `pthread_self()` returns an opaque type `pthread_t` with a large value. Instead, `pthread_threadid_np` returns a system-wide unique integral ID of thread in the location specified by `thread_id`.

Note that `pthread_threadid_np` doesn't seem to exist before macOS 10.6 as mentioned from [C++ spdlog comment](https://github.com/gabime/spdlog/blob/7e635fca68d014934b4af8a1cf874f63989352b7/include/spdlog/details/os-inl.h#L363-L364), we can use `pthread_mach_thread_np(pthread_self())` for earlier versions. But considering it's a fairly early version (wikipedia says its initial release date is August 28, 2009), I don't have a condition to test it. So ignoring this for now until a user reports it.

I ran the 3 ways of getting TID on macOS from GitHub Action and this is results:

```
pthread_self: 4567832064
pthread_threadid_np: 9037
pthread_mach_thread_np(pthread_self()): 259
```

Obviously, `pthread_self` returns a large value that doesn't quite match our perception of common TID. `pthread_threadid_np` and `pthread_mach_thread_np` both look good, but semantically I prefer the former, whose function name implies what we're doing.

---

Other projects also use `pthread_threadid_np` to get TID on macOS:

- LLVM compiler-rt
  - https://reviews.llvm.org/D18951
  - https://github.com/llvm/llvm-project/blob/4c6f95be29c6ce0f89663a5103c58ee63d76cda3/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp#L406

- C++ spdlog
  - https://github.com/gabime/spdlog/blob/7e635fca68d014934b4af8a1cf874f63989352b7/include/spdlog/details/os-inl.h#L370