### PR TITLE
Handle conditional compilation for getting TID on iOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,35 @@ jobs:
     - name: Run clippy nightly for benches
       run: cargo +nightly clippy --all-features --benches
 
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        target: ['', 'x86_64-apple-ios']
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo bash ./.github/workflows/install-deps.sh
+    - name: Install Rust target
+      if: matrix.target != ''
+      run: rustup target add ${{ matrix.target }}
+    - name: Restore cargo caches
+      uses: Swatinem/rust-cache@v1
+    - name: Run check
+      run: |
+        if [[ -z "${{ matrix.target }}" ]]; then
+          cargo check --all-features
+        else
+          cargo check --all-features --target ${{ matrix.target }}
+        fi
+
   check-doc:
     strategy:
       fail-fast: false

--- a/spdlog/src/formatter/pattern_formatter/pattern/thread_id.rs
+++ b/spdlog/src/formatter/pattern_formatter/pattern/thread_id.rs
@@ -12,8 +12,8 @@ use crate::{
 ///
 /// On Linux, this pattern writes the return value of `gettid` to the output.
 ///
-/// On macOS, this pattern writes the return value of `pthread_self` to the
-/// output.
+/// On macOS and iOS, this pattern writes the return value of
+/// `pthread_threadid_np` to the output.
 ///
 /// On Windows, this pattern writes the return value of `GetCurrentThreadId` to
 /// the output.

--- a/spdlog/src/record.rs
+++ b/spdlog/src/record.rs
@@ -269,7 +269,7 @@ fn get_current_tid() -> u64 {
         tid as u64
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     #[must_use]
     fn get_current_tid_inner() -> u64 {
         let mut tid = 0;


### PR DESCRIPTION
Fixes #36.

Currently CI only run `cargo check` for iOS target since `cargo test` needs more effort to configure simulator, and `cargo check` is enough to detect such obvious compilation errors.

@newbeeAirfeeen Can you test this branch on iOS to see if there are any other issues?