### PR TITLE
get_current_tid_inner for ios

### DIFF
--- a/spdlog/src/record.rs
+++ b/spdlog/src/record.rs
@@ -269,7 +269,7 @@ fn get_current_tid() -> u64 {
         tid as u64
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     #[must_use]
     fn get_current_tid_inner() -> u64 {
         let mut tid = 0;


### PR DESCRIPTION
I just confirmed and verified that pthread_threadid_np can indeed be called on ios. This has been compiled on my example