### PR TITLE
Update syn version to 2.0.38

### DIFF
--- a/spdlog-macros/Cargo.toml
+++ b/spdlog-macros/Cargo.toml
@@ -17,4 +17,4 @@ proc-macro = true
 nom = "7.1.1"
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
-syn = { version = "1.0.103", features = ["full"] }
+syn = { version = "2.0.38", features = ["full"] }

--- a/spdlog-macros/src/parse.rs
+++ b/spdlog-macros/src/parse.rs
@@ -194,8 +194,7 @@ pub(crate) struct CustomPatternMapping {
 
 impl Parse for CustomPatternMapping {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let items: Punctuated<_, Token![,]> =
-            input.parse_terminated(CustomPatternMappingItem::parse)?;
+        let items = Punctuated::<CustomPatternMappingItem, Token![,]>::parse_terminated(input)?;
 
         let mapping_pairs = items.into_iter().fold(vec![], |mut prev, item| {
             prev.push((item.name, item.factory));


### PR DESCRIPTION
This PR updates the version of `syn` to 2.0.38. It also resolves various build issues after updating.

This should close #44.