### PR TITLE
Implement `config` feature

### DIFF
--- a/spdlog/Cargo.toml
+++ b/spdlog/Cargo.toml
@@ -32,6 +32,7 @@ release-level-info     = []
 release-level-debug    = []
 release-level-trace    = []
 
+config = ["serde", "erased-serde"]
 source-location = []
 native = []
 libsystemd = ["libsystemd-sys"]
@@ -45,11 +46,13 @@ cfg-if = "1.0.0"
 chrono = "0.4.22"
 crossbeam = { version = "0.8.2", optional = true }
 dyn-clone = "1.0.14"
+erased-serde = { version = "0.3.31", optional = true }
 flexible-string = { version = "0.1.0", optional = true }
 if_chain = "1.0.2"
 is-terminal = "0.4"
 log = { version = "0.4.8", optional = true }
 once_cell = "1.16.0"
+serde = { version = "1.0.163", optional = true }
 spdlog-internal = { version = "=0.1.0", path = "../spdlog-internal", optional = true }
 spdlog-macros = { version = "0.1.0", path = "../spdlog-macros" }
 spin = "0.9.8"
@@ -81,6 +84,7 @@ tracing = "=0.1.37"
 tracing-subscriber = "=0.3.16"
 tracing-appender = "=0.2.2"
 paste = "1.0.14"
+toml = "0.8.6"
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/spdlog/src/config/mod.rs
+++ b/spdlog/src/config/mod.rs
@@ -1,0 +1,24 @@
+mod registry;
+mod source;
+
+pub(crate) mod parse;
+
+pub use registry::*;
+use serde::{de::DeserializeOwned, Deserialize};
+pub use source::*;
+
+use crate::{sync::*, Result};
+
+// TODO: Force `'static` on name?
+//       Builder?
+#[derive(PartialEq, Eq, Hash)]
+pub struct ComponentMetadata<'a> {
+    pub(crate) name: &'a str,
+}
+
+pub trait Configurable: Sized {
+    type Params: DeserializeOwned + Default + Send;
+
+    fn metadata() -> ComponentMetadata<'static>;
+    fn build(params: Self::Params) -> Result<Self>;
+}

--- a/spdlog/src/config/parse.rs
+++ b/spdlog/src/config/parse.rs
@@ -1,0 +1,53 @@
+use erased_serde::Deserializer as ErasedDeserializer;
+use serde::{
+    de::{
+        value::{MapAccessDeserializer, UnitDeserializer},
+        Error as SerdeDeError, MapAccess, Visitor,
+    },
+    Deserializer,
+};
+
+use crate::{config, formatter::*};
+
+pub fn formatter_deser<'de, D>(de: D) -> Result<Option<Box<dyn Formatter>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ParseVisitor;
+
+    impl<'de> Visitor<'de> for ParseVisitor {
+        type Value = Box<dyn Formatter>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a spdlog-rs component")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            let name = map
+                .next_entry::<String, String>()?
+                .filter(|(key, _)| key == "name")
+                .map(|(_, value)| value)
+                .ok_or_else(|| SerdeDeError::missing_field("name"))?;
+
+            let remaining_args = map.size_hint().unwrap(); // I don't know what situation it will be `None``
+
+            let formatter = if remaining_args == 0 {
+                let mut erased_de =
+                    <dyn ErasedDeserializer>::erase(UnitDeserializer::<A::Error>::new());
+                config::registry().build_formatter(&name, &mut erased_de)
+            } else {
+                let mut erased_de =
+                    <dyn ErasedDeserializer>::erase(MapAccessDeserializer::new(map));
+                config::registry().build_formatter(&name, &mut erased_de)
+            }
+            .map_err(|err| SerdeDeError::custom(err))?;
+
+            Ok(formatter)
+        }
+    }
+
+    Ok(Some(de.deserialize_map(ParseVisitor)?))
+}

--- a/spdlog/src/config/registry.rs
+++ b/spdlog/src/config/registry.rs
@@ -1,0 +1,276 @@
+use std::collections::HashMap;
+
+use erased_serde::Deserializer as ErasedDeserializer;
+
+use super::ComponentMetadata;
+use crate::{
+    config::Configurable,
+    error::ConfigError,
+    formatter::{Formatter, FullFormatter, PatternFormatter, RuntimePattern},
+    sink::*,
+    sync::*,
+    Error, Result, Sink,
+};
+
+type StdResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+// https://github.com/dtolnay/erased-serde/issues/97
+mod erased_serde_ext {
+    use erased_serde::Result;
+    use serde::de::Deserialize;
+
+    use super::*;
+
+    pub trait ErasedDeserialize<'a> {
+        fn erased_deserialize_in_place(
+            &mut self,
+            de: &mut dyn ErasedDeserializer<'a>,
+        ) -> Result<()>;
+    }
+
+    pub trait ErasedDeserializeOwned: for<'a> ErasedDeserialize<'a> {}
+
+    impl<T: for<'a> ErasedDeserialize<'a>> ErasedDeserializeOwned for T {}
+
+    impl<'a, T: Deserialize<'a>> ErasedDeserialize<'a> for T {
+        fn erased_deserialize_in_place(
+            &mut self,
+            de: &mut dyn ErasedDeserializer<'a>,
+        ) -> Result<()> {
+            Deserialize::deserialize_in_place(de, self)
+        }
+    }
+}
+use erased_serde_ext::*;
+
+type ComponentDeser<C: Configurable> = fn(de: &mut dyn ErasedDeserializer) -> Result<C>;
+
+type RegisteredComponents<C: Configurable> = HashMap<&'static str, ComponentDeser<C>>;
+
+pub struct Registry {
+    sink: Mutex<RegisteredComponents<Box<dyn Sink>>>,
+    formatter: Mutex<RegisteredComponents<Box<dyn Formatter>>>,
+
+    // TODO: Consider make them compile-time
+    builtin_sink: Mutex<RegisteredComponents<Box<dyn Sink>>>,
+    builtin_formatter: Mutex<RegisteredComponents<Box<dyn Formatter>>>,
+}
+
+impl Registry {
+    pub fn register_sink<S>(&mut self) -> Result<()>
+    where
+        S: Sink + Configurable + 'static,
+    {
+        self.register_sink_inner::<S>()
+    }
+
+    pub fn register_formatter<F>(&mut self) -> Result<()>
+    where
+        F: Formatter + Configurable + 'static,
+    {
+        self.register_formatter_inner::<F>()
+    }
+}
+
+impl Registry {
+    pub(crate) fn with_builtin() -> Self {
+        let mut registry = Self {
+            sink: Mutex::new(HashMap::new()),
+            formatter: Mutex::new(HashMap::new()),
+            builtin_sink: Mutex::new(HashMap::new()),
+            builtin_formatter: Mutex::new(HashMap::new()),
+        };
+        registry.register_builtin().unwrap(); // Builtin components should not fail to register
+        registry
+    }
+
+    fn register_builtin(&mut self) -> Result<()> {
+        self.register_builtin_sink::<FileSink>()?;
+        self.register_builtin_formatter::<FullFormatter>()?;
+        self.register_builtin_formatter::<PatternFormatter<RuntimePattern>>()?;
+        Ok(())
+    }
+
+    pub(crate) fn build_sink(
+        &self,
+        name: &str,
+        de: &mut dyn ErasedDeserializer,
+    ) -> Result<Box<dyn Sink>> {
+        self.builtin_sink
+            .lock_expect()
+            .get(name)
+            .ok_or_else(|| Error::Config(ConfigError::UnknownComponent(name.to_string())))
+            .and_then(|f| f(de))
+    }
+
+    pub(crate) fn build_formatter(
+        &self,
+        name: &str,
+        de: &mut dyn ErasedDeserializer,
+    ) -> Result<Box<dyn Formatter>> {
+        self.builtin_formatter
+            .lock_expect()
+            .get(name)
+            .ok_or_else(|| Error::Config(ConfigError::UnknownComponent(name.to_string())))
+            .and_then(|f| f(de))
+    }
+
+    impl_registers! {
+        fn register_sink_inner => sink, Sink,
+        fn register_formatter_inner => formatter, Formatter,
+        pub(crate) fn register_builtin_sink => builtin_sink, Sink,
+        pub(crate) fn register_builtin_formatter => builtin_formatter, Formatter,
+    }
+}
+
+// TODO: Append prefix '$' for custom components
+macro_rules! impl_registers {
+    ( $($vis:vis fn $fn_name:ident => $var:ident, $trait:ident),+ $(,)? ) => {
+        $($vis fn $fn_name<C>(&mut self) -> Result<()>
+        where
+            C: $trait + Configurable + 'static,
+        {
+            let f = |de: &mut dyn ErasedDeserializer| -> Result<Box<dyn $trait>> {
+                let mut params = C::Params::default();
+                params.erased_deserialize_in_place(de).unwrap(); // TODO: Wrong input will trigger a Err, handle it!
+                Ok(Box::new(C::build(params)?))
+            };
+
+            self.$var
+                .lock_expect()
+                .insert(C::metadata().name, f)
+                .map_or(Ok(()), |_| Err(Error::Config(ConfigError::MultipleRegistration)))
+        })+
+    };
+}
+use impl_registers;
+
+// TODO: Consider removing the `'static` lifetime. Maybe using `Arc<>`?
+pub(crate) fn registry() -> &'static Registry {
+    static REGISTRY: Lazy<Registry> = Lazy::new(Registry::with_builtin);
+    &REGISTRY
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Write;
+
+    use serde::Deserializer;
+
+    use super::*;
+    use crate::{formatter::FmtExtraInfo, prelude::*, ErrorHandler, Record, StringBuf};
+
+    pub struct MockSink(i32);
+
+    impl Sink for MockSink {
+        fn log(&self, _record: &Record) -> Result<()> {
+            unimplemented!()
+        }
+
+        fn flush(&self) -> Result<()> {
+            unimplemented!()
+        }
+
+        fn level_filter(&self) -> LevelFilter {
+            unimplemented!()
+        }
+
+        fn set_level_filter(&self, _level_filter: LevelFilter) {
+            unimplemented!()
+        }
+
+        fn set_formatter(&self, _formatter: Box<dyn Formatter>) {
+            unimplemented!()
+        }
+
+        fn set_error_handler(&self, handler: Option<ErrorHandler>) {
+            handler.unwrap()(Error::__ForInternalTestsUseOnly(self.0))
+        }
+    }
+
+    #[derive(Default, serde::Deserialize)]
+    pub struct MockParams {
+        arg: i32,
+    }
+
+    impl Configurable for MockSink {
+        type Params = MockParams;
+
+        fn metadata() -> ComponentMetadata<'static> {
+            ComponentMetadata { name: "MockSink" }
+        }
+
+        fn build(params: Self::Params) -> Result<Self> {
+            Ok(Self(params.arg))
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct MockFormatter(i32);
+
+    impl Formatter for MockFormatter {
+        fn format(&self, _record: &Record, dest: &mut StringBuf) -> Result<FmtExtraInfo> {
+            write!(dest, "{}", self.0).unwrap();
+            Ok(FmtExtraInfo::new())
+        }
+
+        fn clone_box(&self) -> Box<dyn Formatter> {
+            Box::new(self.clone())
+        }
+    }
+
+    impl Configurable for MockFormatter {
+        type Params = MockParams;
+
+        fn metadata() -> ComponentMetadata<'static> {
+            ComponentMetadata {
+                name: "MockFormatter",
+            }
+        }
+
+        fn build(params: Self::Params) -> Result<Self> {
+            Ok(Self(params.arg))
+        }
+    }
+
+    fn registry_for_test() -> Registry {
+        let mut registry = Registry::with_builtin();
+        registry.register_sink::<MockSink>().unwrap();
+        registry.register_formatter::<MockFormatter>().unwrap();
+        registry
+    }
+
+    #[test]
+    fn build_sink_from_params() {
+        let registry = registry_for_test();
+
+        let mut erased_de =
+            <dyn ErasedDeserializer>::erase(toml::Deserializer::new("arg = 114514"));
+        let sink = registry.build_sink("MockSink", &mut erased_de).unwrap();
+        sink.set_error_handler(Some(|err| {
+            assert!(matches!(err, Error::__ForInternalTestsUseOnly(114514)))
+        }));
+
+        // TODO: test wrong kind
+    }
+
+    #[test]
+    fn build_formatter_from_params() {
+        let registry = registry_for_test();
+
+        let mut erased_de =
+            <dyn ErasedDeserializer>::erase(toml::Deserializer::new("arg = 1919810"));
+        let formatter = registry
+            .build_formatter("MockFormatter", &mut erased_de)
+            .unwrap();
+        let mut dest = StringBuf::new();
+        formatter
+            .format(&Record::new(Level::Info, ""), &mut dest)
+            .unwrap();
+        assert_eq!(dest, "1919810")
+
+        // TODO: test wrong kind
+    }
+
+    // TODO: Test custom components
+}

--- a/spdlog/src/config/source.rs
+++ b/spdlog/src/config/source.rs
@@ -1,0 +1,18 @@
+use std::{marker::PhantomData, path::Path};
+
+pub trait Source {
+    fn file<P>(path: P)
+    where
+        P: AsRef<Path>,
+    {
+    }
+}
+
+// TODO: place it into a format mod?
+pub struct Toml {
+    phantom: PhantomData<()>,
+}
+
+impl Source for Toml {
+    //
+}

--- a/spdlog/src/error.rs
+++ b/spdlog/src/error.rs
@@ -99,6 +99,13 @@ pub enum Error {
     #[cfg(feature = "runtime-pattern")]
     #[error("failed to build pattern at runtime: {0}")]
     BuildPattern(BuildPatternError),
+
+    #[error("TODO: {0}")]
+    Config(ConfigError), // TODO: Better name?
+
+    #[cfg(test)]
+    #[error("{0}")]
+    __ForInternalTestsUseOnly(i32),
 }
 
 /// This error type contains a variety of possible invalid arguments.
@@ -246,6 +253,14 @@ pub(crate) enum BuildPatternErrorInner {
     Internal(spdlog_internal::pattern_parser::Error),
     #[error("invalid placeholder for custom pattern '{0}'")]
     InvalidCustomPlaceholder(String),
+}
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("TODO: MultipleRegistration")]
+    MultipleRegistration,
+    #[error("TODO: UnknownComponent ({0})")]
+    UnknownComponent(String), // TODO: Better name?
 }
 
 /// The result type of this crate.

--- a/spdlog/src/formatter/full_formatter.rs
+++ b/spdlog/src/formatter/full_formatter.rs
@@ -1,12 +1,16 @@
 //! Provides a full info formatter.
 
-use std::fmt::{self, Write};
+use std::{
+    fmt::{self, Write},
+    result::Result as StdResult,
+};
 
 use cfg_if::cfg_if;
 
 use crate::{
+    config::{ComponentMetadata, Configurable},
     formatter::{FmtExtraInfo, Formatter, LOCAL_TIME_CACHER},
-    Error, Record, StringBuf, EOL,
+    Error, Record, Result, StringBuf, EOL,
 };
 
 #[rustfmt::skip]
@@ -54,7 +58,7 @@ impl FullFormatter {
         &self,
         record: &Record,
         dest: &mut StringBuf,
-    ) -> Result<FmtExtraInfo, fmt::Error> {
+    ) -> StdResult<FmtExtraInfo, fmt::Error> {
         cfg_if! {
             if #[cfg(not(feature = "flexible-string"))] {
                 dest.reserve(crate::string_buf::RESERVE_SIZE);
@@ -117,6 +121,20 @@ impl Formatter for FullFormatter {
 impl Default for FullFormatter {
     fn default() -> FullFormatter {
         FullFormatter::new()
+    }
+}
+
+impl Configurable for FullFormatter {
+    type Params = ();
+
+    fn metadata() -> ComponentMetadata<'static> {
+        ComponentMetadata {
+            name: "FullFormatter",
+        }
+    }
+
+    fn build(params: Self::Params) -> Result<Self> {
+        Ok(FullFormatter::new())
     }
 }
 

--- a/spdlog/src/formatter/mod.rs
+++ b/spdlog/src/formatter/mod.rs
@@ -112,3 +112,20 @@ impl FmtExtraInfoBuilder {
         self.info
     }
 }
+
+/// There is no easy way to implement `PartialEq` for `dyn T`. we just do it for
+/// testing, so we implement it this way
+#[cfg(test)]
+impl PartialEq for dyn Formatter {
+    fn eq(&self, other: &Self) -> bool {
+        let record = Record::new(crate::Level::Critical, "this is a mock record");
+
+        let (mut self_result, mut other_result) = (StringBuf::new(), StringBuf::new());
+        let (self_extra, other_extra) = (
+            self.format(&record, &mut self_result).unwrap(),
+            other.format(&record, &mut other_result).unwrap(),
+        );
+
+        (self_result, self_extra) == (other_result, other_extra)
+    }
+}

--- a/spdlog/src/formatter/pattern_formatter/runtime.rs
+++ b/spdlog/src/formatter/pattern_formatter/runtime.rs
@@ -1,5 +1,6 @@
 use std::convert::Infallible;
 
+use serde::Deserialize;
 use spdlog_internal::pattern_parser::{
     error::TemplateError,
     parse::{Template, TemplateToken},
@@ -8,8 +9,9 @@ use spdlog_internal::pattern_parser::{
     Result as PatternParserResult,
 };
 
-use super::{Pattern, PatternContext, __pattern as pattern};
+use super::{Pattern, PatternContext, PatternFormatter, __pattern as pattern};
 use crate::{
+    config::{ComponentMetadata, Configurable},
     error::{BuildPatternErrorInner, Error},
     Record, Result, StringBuf,
 };
@@ -136,6 +138,12 @@ impl Pattern for RuntimePattern {
         }
         Ok(())
     }
+}
+
+#[derive(Default, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct PatternFormatterRuntimePatternParams {
+    template: String,
 }
 
 #[rustfmt::skip] // rustfmt currently breaks some empty lines if `#[doc = include_str!("xxx")]` exists
@@ -344,6 +352,20 @@ fn build_builtin_pattern(builtin: &BuiltInFormatter) -> Box<dyn Pattern> {
     )
 }
 
+impl Configurable for PatternFormatter<RuntimePattern> {
+    type Params = PatternFormatterRuntimePatternParams;
+
+    fn metadata() -> ComponentMetadata<'static> {
+        ComponentMetadata {
+            name: "PatternFormatter",
+        }
+    }
+
+    fn build(params: Self::Params) -> Result<Self> {
+        Ok(Self::new(RuntimePattern::new(params.template)?))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -414,5 +436,20 @@ mod tests {
                 .build(),
             Err(Error::BuildPattern(_))
         ));
+    }
+
+    #[test]
+    fn deser_params() {
+        assert!(
+            toml::from_str::<PatternFormatterRuntimePatternParams>(
+                r#"template = "[{level}] {payload}""#,
+            )
+            .unwrap()
+                == PatternFormatterRuntimePatternParams {
+                    template: "[{level}] {payload}".to_string()
+                }
+        );
+
+        // TODO: Test ill-formed template string err
     }
 }

--- a/spdlog/src/level.rs
+++ b/spdlog/src/level.rs
@@ -55,6 +55,7 @@ const LOG_LEVEL_SHORT_NAMES: [&str; Level::count()] = ["C", "E", "W", "I", "D", 
 /// [`log!`]: crate::log!
 #[repr(u16)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Level {
     /// Designates critical errors.
     Critical = 0,
@@ -201,6 +202,7 @@ impl FromStr for Level {
 /// ```
 #[repr(align(4))]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LevelFilter {
     /// Disables all levels.
     Off,

--- a/spdlog/src/lib.rs
+++ b/spdlog/src/lib.rs
@@ -249,6 +249,7 @@
 #![cfg_attr(all(doc, CHANNEL_NIGHTLY), feature(doc_auto_cfg))]
 #![warn(missing_docs)]
 
+pub mod config;
 mod env_level;
 pub mod error;
 pub mod formatter;

--- a/spdlog/src/sink/async_sink/async_pool_sink.rs
+++ b/spdlog/src/sink/async_sink/async_pool_sink.rs
@@ -37,7 +37,7 @@ impl AsyncPoolSink {
     #[must_use]
     pub fn builder() -> AsyncPoolSinkBuilder {
         AsyncPoolSinkBuilder {
-            level_filter: helper::SINK_DEFAULT_LEVEL_FILTER,
+            level_filter: helper::sink_default_level_filter(),
             overflow_policy: OverflowPolicy::Block,
             sinks: Sinks::new(),
             thread_pool: None,

--- a/spdlog/src/sink/helper.rs
+++ b/spdlog/src/sink/helper.rs
@@ -1,6 +1,10 @@
+use std::result::Result as StdResult;
+
 use cfg_if::cfg_if;
+use serde::Deserialize;
 
 use crate::{
+    config::Configurable,
     formatter::{Formatter, FullFormatter},
     prelude::*,
     sync::*,
@@ -16,7 +20,9 @@ cfg_if! {
     }
 }
 
-pub(crate) const SINK_DEFAULT_LEVEL_FILTER: LevelFilter = LevelFilter::All;
+pub(crate) const fn sink_default_level_filter() -> LevelFilter {
+    LevelFilter::All
+}
 
 pub(crate) struct CommonImpl {
     pub(crate) level_filter: Atomic<LevelFilter>,
@@ -60,17 +66,28 @@ impl CommonImpl {
     }
 }
 
+#[derive(Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
 pub(crate) struct CommonBuilderImpl {
+    #[serde(default = "sink_default_level_filter")]
     pub(crate) level_filter: LevelFilter,
+    #[serde(default, deserialize_with = "crate::config::parse::formatter_deser")]
     pub(crate) formatter: Option<Box<dyn Formatter>>,
+    #[serde(skip)]
     pub(crate) error_handler: Option<ErrorHandler>,
+}
+
+impl Default for CommonBuilderImpl {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CommonBuilderImpl {
     #[must_use]
     pub(crate) fn new() -> Self {
         Self {
-            level_filter: SINK_DEFAULT_LEVEL_FILTER,
+            level_filter: sink_default_level_filter(),
             formatter: None,
             error_handler: None,
         }

--- a/spdlog/src/sink/mod.rs
+++ b/spdlog/src/sink/mod.rs
@@ -118,3 +118,12 @@ pub trait Sink: Sync + Send {
 
 /// A container for [`Sink`]s.
 pub type Sinks = Vec<Arc<dyn Sink>>;
+
+/// There is no easy way to implement `PartialEq` for `dyn T`. we just do it for
+/// testing, so we implement it this way
+#[cfg(test)]
+impl PartialEq for dyn Sink {
+    fn eq(&self, other: &Self) -> bool {
+        self.level_filter() == other.level_filter()
+    }
+}


### PR DESCRIPTION
This is an early implementation of #25 in progress. It is currently incomplete, just to preview its API and approach.

Note to self: Remember to change the base branch to `main` or `main-dev` before merging.

---

We mainly introduced a new trait:

```rust
pub trait Configurable: Sized {
    type Params: DeserializeOwned + Default + Send;

    fn metadata() -> ComponentMetadata;
    fn build(params: Self::Params) -> Result<Self>;
}
```

then we implement it for built-in sinks and formatters like:

```rust
impl Configurable for FileSink {
    type Params = FileSinkParams;

    fn metadata() -> ComponentMetadata {
        ComponentMetadata { name: "FileSink" }
    }

    fn build(params: Self::Params) -> Result<Self> {
        let mut builder = FileSink::builder()
            .level_filter(params.0.common_builder_impl.level_filter)
            .path(params.0.path)
            .truncate(params.0.truncate);
        if let Some(formatter) = params.0.common_builder_impl.formatter {
            builder = builder.formatter(formatter);
        }
        builder.build()
    }
}
```

```rust
impl Configurable for PatternFormatter<RuntimePattern> {
    type Params = PatternFormatterRuntimePatternParams;

    fn metadata() -> ComponentMetadata {
        ComponentMetadata {
            name: "PatternFormatter",
        }
    }

    fn build(params: Self::Params) -> Result<Self> {
        Ok(Self::new(RuntimePattern::new(params.template)?))
    }
}
```

Of course, users can implement this trait for their own sinks and formatters.

With the power of [`erased-serde`](https://github.com/dtolnay/erased-serde), we can cast the `type Params` to a `dyn erased_serde::Deserializer` to be used later. (Check `config/registry.rs`)

When we deserializing a sink or formatter, we will first read the `name` field, then look it up from the registry, if found, deserializing the rest of the fields using the erased stored `Deserializer`. (Check `config/parse.rs`)

---

This whole deserialization process will be very hidden to users! `trait Configurable` and `.register_xxx()` is the only thing they need to care about if they have their own sink / formatter.