### PR TITLE
Add support for log target

### DIFF
--- a/spdlog/tests/log_crate_proxy.rs
+++ b/spdlog/tests/log_crate_proxy.rs
@@ -17,7 +17,7 @@ fn test_source_location() {
     let sink = Arc::new(StringSink::with(|b| b.formatter(formatter)));
     let logger = Arc::new(build_test_logger(|b| b.sink(sink.clone())));
 
-    spdlog::init_log_crate_proxy().unwrap();
+    spdlog::init_log_crate_proxy().ok();
     spdlog::log_crate_proxy().set_logger(Some(logger));
     log::set_max_level(log::LevelFilter::Trace);
 
@@ -26,4 +26,19 @@ fn test_source_location() {
         sink.clone_string(),
         "(log_crate_proxy::log_crate_proxy.rs) text\n"
     );
+}
+
+#[cfg(feature = "log")]
+#[test]
+fn test_target() {
+    let formatter = Box::new(PatternFormatter::new(pattern!("[{logger}] {payload}{eol}")));
+    let sink = Arc::new(StringSink::with(|b| b.formatter(formatter)));
+    let logger = Arc::new(build_test_logger(|b| b.sink(sink.clone())));
+
+    spdlog::init_log_crate_proxy().ok();
+    spdlog::log_crate_proxy().set_logger(Some(logger));
+    log::set_max_level(log::LevelFilter::Trace);
+
+    log::info!(target: "MyLogger", "body");
+    assert_eq!(sink.clone_string(), "[MyLogger] body\n");
 }


### PR DESCRIPTION
The `log` crate support specifying log target in the syntax below:

```rust
info!(target: "log-target", "log body");
//    ^~~~~~~~~~~~~~~~~~~~
```

The log target is a string that can be fully customized. Before this PR, this field is not used in spdlog-rs. Actually it can be used as a way to announce the logger name when you want to emit logs in a library through the `log` crate. Thus, in this PR, I used this information as another source of logger names.

Specifically, when constructing a `spdlog::Record` from a `log::Record` with a specific `spdlog::Logger`: (see also [source](https://github.com/Lancern/spdlog-rs/blob/log-target/spdlog/src/record.rs#L123-L154))

- If the `spdlog::Logger` has a logger name configured, the logger name of the constructed `spdlog::Record` will be that name.
- Otherwise, if the `log::Record` has a non-empty `target`, the logger name of the constructed `spdlog::Record` will be that value.
- Otherwise, the logger name of the constructed `spdlog::Record` will be `None`.

# API Breaking

This PR indeed has potential impacts. It's actually API breaking because the signature of `spdlog::Record::logger_name` is updated from:

```rust
impl<'a> Record<'a> {
    fn logger_name(&self) -> Option<&'a str>;
}
```

to:

```rust
impl<'a> Record<'a> {
    fn logger_name(&self) -> Option<&str>;
}
```

. This is because we have to change the way we store the logger name in `spdlog::Record`. Before this PR, the logger name is simply represented by a `&'a str`. In this PR, I need to update its type to `Cow<&'a, str>` because I have to store an owned version of the log target name if the record is constructed from a log crate record.

But I believe the impact of this change should be minimal.