### PR TITLE
Add methods to provide on spawn and on finish tasks to thread pool builder

### DIFF
--- a/spdlog/src/thread_pool.rs
+++ b/spdlog/src/thread_pool.rs
@@ -126,14 +126,20 @@ impl ThreadPoolBuilder {
     /// Provide a function that will be called on each thread of the thread pool
     /// immediately after it is spawned. This can, for example, be used to set
     /// core affinity for each thread.
-    pub fn on_thread_spawn(&mut self, f: impl Fn() + Send + Sync + 'static) -> &mut Self {
+    pub fn on_thread_spawn<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
         self.on_thread_spawn = Some(Arc::new(f));
         self
     }
 
     /// Provide a function that will be called on each thread of the thread pool
     /// just before the thread finishes.
-    pub fn on_thread_finish(&mut self, f: impl Fn() + Send + Sync + 'static) -> &mut Self {
+    pub fn on_thread_finish<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
         self.on_thread_finish = Some(Arc::new(f));
         self
     }


### PR DESCRIPTION
Following on from discussion in #51, this PR adds two methods to `ThreadPoolBuilder`: `on_thread_spawn` and `on_thread_finish`. These allow for functions to be provided that are called immediately after each pool thread is spawned and immediately before it finishes. 

An example of where these may be useful is for setting core affinity for each thread in the thread pool. This use case inspired the original PR (#51); the implementation in this PR is a completely general interface that also makes this possible.