### PR TITLE
Check `active` even if `Condvar` times out in `PeriodicWorker`

### DIFF
--- a/spdlog/src/periodic_worker.rs
+++ b/spdlog/src/periodic_worker.rs
@@ -21,13 +21,13 @@ impl PeriodicWorker {
         Self {
             active: active.clone(),
             thread: Some(thread::spawn(move || loop {
-                let guard = active.0.lock_expect();
-                let (_, res) = active
+                let flag = active.0.lock_expect();
+                let (flag, res) = active
                     .1
-                    .wait_timeout_while(guard, interval, |active| *active)
+                    .wait_timeout_while(flag, interval, |flag| *flag)
                     .unwrap();
 
-                if !res.timed_out() || !callback() {
+                if !res.timed_out() || !*flag || !callback() {
                     return;
                 }
             })),


### PR DESCRIPTION
Fixes #60.

Before this PR, we didn't check the `active` flag if `wait_timeout_while` returns due to a timeout. There may be a small probability issue with this, i.e. `PeriodicWorker` being dropped a short time after the `wait_timeout_while` timeout has returned will potentially result in an infinite join.