### PR TITLE
Optionally format log file path with time in time point file rotator

### DIFF
--- a/spdlog-macros/src/lib.rs
+++ b/spdlog-macros/src/lib.rs
@@ -26,6 +26,13 @@ pub fn runtime_pattern(input: TokenStream) -> TokenStream {
     into_or_error(pattern::runtime_pattern_impl(runtime_pattern))
 }
 
+#[proc_macro]
+pub fn runtime_pattern_disabled(_: TokenStream) -> TokenStream {
+    panic!(
+        "macro `runtime_pattern` required to enable crate feature `runtime-pattern` for spdlog-rs"
+    );
+}
+
 fn into_or_error(result: Result<TokenStream2>) -> TokenStream {
     match result {
         Ok(stream) => stream.into(),

--- a/spdlog/src/formatter/pattern_formatter/mod.rs
+++ b/spdlog/src/formatter/pattern_formatter/mod.rs
@@ -342,6 +342,10 @@ use crate::{
 /// [`FullFormatter`]: crate::formatter::FullFormatter
 pub use ::spdlog_macros::pattern;
 
+// Emit a compile error if the feature is not enabled.
+#[cfg(not(feature = "runtime-pattern"))]
+pub use ::spdlog_macros::runtime_pattern_disabled as runtime_pattern;
+
 /// Formats logs according to a specified pattern.
 #[derive(Clone)]
 pub struct PatternFormatter<P> {

--- a/spdlog/tests/compile_fail.rs
+++ b/spdlog/tests/compile_fail.rs
@@ -5,4 +5,6 @@ fn compile_fail() {
     t.compile_fail("tests/compile_fail/pattern_macro_*.rs");
     #[cfg(feature = "runtime-pattern")]
     t.compile_fail("tests/compile_fail/pattern_runtime_macro_*.rs");
+    #[cfg(not(feature = "runtime-pattern"))]
+    t.compile_fail("tests/compile_fail/pattern_runtime_disabled.rs");
 }

--- a/spdlog/tests/compile_fail/pattern_runtime_disabled.rs
+++ b/spdlog/tests/compile_fail/pattern_runtime_disabled.rs
@@ -1,0 +1,7 @@
+use spdlog::formatter::runtime_pattern;
+
+fn runtime_pattern() {
+    runtime_pattern!("{logger}");
+}
+
+fn main() {}

--- a/spdlog/tests/compile_fail/pattern_runtime_disabled.stderr
+++ b/spdlog/tests/compile_fail/pattern_runtime_disabled.stderr
@@ -1,0 +1,7 @@
+error: proc macro panicked
+ --> tests/compile_fail/pattern_runtime_disabled.rs:4:5
+  |
+4 |     runtime_pattern!("{logger}");
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: macro `runtime_pattern` required to enable crate feature `runtime-pattern` for spdlog-rs


### PR DESCRIPTION
Aim is to allow custom file names and paths on time point rotation, rather than the default behaviour of appending the date/time to the file name given in the base path.