### PR TITLE
Implement `get_current_tid_inner` for FreeBSD and Illumos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        target: ['', 'x86_64-apple-ios']
+        target: ['', 'x86_64-apple-ios', 'x86_64-unknown-freebsd', 'x86_64-unknown-illumos']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository

--- a/spdlog/src/record.rs
+++ b/spdlog/src/record.rs
@@ -225,6 +225,20 @@ fn get_current_tid() -> u64 {
         tid as u64
     }
 
+    #[cfg(target_os = "freebsd")]
+    #[must_use]
+    fn get_current_tid_inner() -> u64 {
+        let tid = unsafe { libc::pthread_getthreadid_np() };
+        tid as u64
+    }
+
+    #[cfg(target_os = "illumos")]
+    #[must_use]
+    fn get_current_tid_inner() -> u64 {
+        let tid = unsafe { libc::thr_self() };
+        tid as u64
+    }
+
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     #[must_use]
     fn get_current_tid_inner() -> u64 {


### PR DESCRIPTION
Fixes #82.

### References

- FreeBSD: https://github.com/gabime/spdlog/blob/f355b3d58f7067eee1706ff3c801c2361011f3d5/include/spdlog/details/os-inl.h#L325-L326
- Illumos: https://github.com/gabime/spdlog/blob/f355b3d58f7067eee1706ff3c801c2361011f3d5/include/spdlog/details/os-inl.h#L331-L332

We don't use `pthread_self` as it returns a opaque pointer, and a pointer value is a little wide for using as an identifier of thread.

---

CC @unknowndevQwQ could you check if this PR works for you?