### PR TITLE
CI check all tier 1 and tier 2 targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,32 +113,69 @@ jobs:
         CARGO_TERM_COLOR=never cargo +nightly clippy --all-features --tests --examples 2>> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
+  check-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      targets_matrix: ${{ steps.gen-matrix.outputs.targets_matrix }}
+    steps:
+    - name: Install Rust nightly
+      run: rustup toolchain install nightly
+    - name: Generate matrix for all tier 1 and tier 2 targets
+      id: gen-matrix
+      run: |
+        TARGETS=$(rustc +nightly --print all-target-specs-json -Z unstable-options \
+          | jq -c "map_values(.metadata.tier) \
+            | to_entries \
+            | map({tier: .value, triplet: .key} \
+            | select(.tier == 1 or .tier == 2)) \
+            | sort_by(.tier)")
+        echo "targets_matrix=$TARGETS" >> "$GITHUB_OUTPUT"
+        echo $TARGETS | jq
+
   check:
+    needs: check-matrix
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        target: ['', 'x86_64-apple-ios']
-    runs-on: ${{ matrix.os }}
+        target: ${{ fromJSON(needs.check-matrix.outputs.targets_matrix) }}
+    runs-on: 'ubuntu-latest'
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Disable bench dependencies
       run: ./.github/workflows/disable-bench-deps.sh
-    - name: Install dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo bash ./.github/workflows/install-deps.sh
-    - name: Install Rust target
-      if: matrix.target != ''
-      run: rustup target add ${{ matrix.target }}
+    - name: Install Rust tier ${{ matrix.target.tier }} target ${{ matrix.target.triplet }}
+      run: rustup target add ${{ matrix.target.triplet }}
     - name: Restore cargo caches
       uses: Swatinem/rust-cache@v2
-    - name: Run check
+    - name: Run check for tier ${{ matrix.target.tier }} target ${{ matrix.target.triplet }}
       run: |
-        if [[ -z "${{ matrix.target }}" ]]; then
-          cargo check --all-features
+        # Exclude dependency features
+        FEATURES=$(cargo metadata --format-version=1 --no-deps \
+          | jq -r ".packages[] \
+            | select(.name == \"spdlog-rs\") \
+            | .features \
+            | keys \
+            | map(select(contains(\"libsystemd\") | not)) \
+            | join(\",\")")
+        echo "Checking with features: $FEATURES"
+
+        # Some upstream crates don't support some targets, so we ignore all errors that don't come from our own crates
+        OUR_ERRORS=$(cargo check --features $FEATURES --target ${{ matrix.target.triplet }} --message-format=json \
+          | jq "select(.reason == \"compiler-message\" \
+            and (.target.name | startswith(\"spdlog\")) \
+            and .message.level == \"error\") \
+            | [.]") || true
+        OUR_ERRORS_COUNT=$(echo ${OUR_ERRORS:=[]} | jq -r length)
+
+        # Rerun for human-readable error outputs
+        cargo check --features $FEATURES --target ${{ matrix.target.triplet }} || true
+
+        if [[ "$OUR_ERRORS_COUNT" != "0" ]]; then
+          echo "Found errors from our crates. Fail!"
+          exit 1
         else
-          cargo check --all-features --target ${{ matrix.target }}
+          echo "No error found from our crates. Pass!"
         fi
 
   check-doc:

--- a/spdlog-macros/src/lib.rs
+++ b/spdlog-macros/src/lib.rs
@@ -26,6 +26,13 @@ pub fn runtime_pattern(input: TokenStream) -> TokenStream {
     into_or_error(pattern::runtime_pattern_impl(runtime_pattern))
 }
 
+#[proc_macro]
+pub fn runtime_pattern_disabled(_: TokenStream) -> TokenStream {
+    panic!(
+        "macro `runtime_pattern` required to enable crate feature `runtime-pattern` for spdlog-rs"
+    );
+}
+
 fn into_or_error(result: Result<TokenStream2>) -> TokenStream {
     match result {
         Ok(stream) => stream.into(),

--- a/spdlog/src/formatter/pattern_formatter/mod.rs
+++ b/spdlog/src/formatter/pattern_formatter/mod.rs
@@ -342,6 +342,10 @@ use crate::{
 /// [`FullFormatter`]: crate::formatter::FullFormatter
 pub use ::spdlog_macros::pattern;
 
+// Emit a compile error if the feature is not enabled.
+#[cfg(not(feature = "runtime-pattern"))]
+pub use ::spdlog_macros::runtime_pattern_disabled as runtime_pattern;
+
 /// Formats logs according to a specified pattern.
 #[derive(Clone)]
 pub struct PatternFormatter<P> {

--- a/spdlog/src/lib.rs
+++ b/spdlog/src/lib.rs
@@ -291,8 +291,7 @@ pub mod re_export;
 mod record;
 pub mod sink;
 mod source_location;
-#[doc(hidden)]
-pub mod string_buf;
+mod string_buf;
 mod sync;
 pub mod terminal_style;
 #[cfg(test)]

--- a/spdlog/src/lib.rs
+++ b/spdlog/src/lib.rs
@@ -328,7 +328,7 @@ use std::{
 
 use cfg_if::cfg_if;
 use error::EnvLevelError;
-use sink::{Sink, StdStream, StdStreamSink};
+use sink::{Sink, StdStreamSink};
 use sync::*;
 
 /// The statically resolved log level filter.
@@ -388,13 +388,13 @@ static DEFAULT_LOGGER: OnceCell<ArcSwap<Logger>> = OnceCell::new();
 fn default_logger_ref() -> &'static ArcSwap<Logger> {
     DEFAULT_LOGGER.get_or_init(|| {
         let stdout = StdStreamSink::builder()
-            .std_stream(StdStream::Stdout)
+            .stdout()
             .level_filter(LevelFilter::MoreVerbose(Level::Warn))
             .build()
             .unwrap();
 
         let stderr = StdStreamSink::builder()
-            .std_stream(StdStream::Stderr)
+            .stderr()
             .level_filter(LevelFilter::MoreSevereEqual(Level::Warn))
             .build()
             .unwrap();

--- a/spdlog/src/sink/std_stream_sink.rs
+++ b/spdlog/src/sink/std_stream_sink.rs
@@ -217,6 +217,30 @@ pub struct StdStreamSinkBuilder<ArgSS> {
 }
 
 impl<ArgSS> StdStreamSinkBuilder<ArgSS> {
+    /// Specifies the target standard stream as stdout.
+    ///
+    /// This is equivalent to `std_stream(StdStream::Stdout)`.
+    #[must_use]
+    pub fn stdout(self) -> StdStreamSinkBuilder<StdStream> {
+        StdStreamSinkBuilder {
+            common_builder_impl: self.common_builder_impl,
+            std_stream: StdStream::Stdout,
+            style_mode: self.style_mode,
+        }
+    }
+
+    /// Specifies the target standard stream as stderr.
+    ///
+    /// This is equivalent to `std_stream(StdStream::Stderr)`.
+    #[must_use]
+    pub fn stderr(self) -> StdStreamSinkBuilder<StdStream> {
+        StdStreamSinkBuilder {
+            common_builder_impl: self.common_builder_impl,
+            std_stream: StdStream::Stderr,
+            style_mode: self.style_mode,
+        }
+    }
+
     /// Specifies the target standard stream.
     ///
     /// This parameter is **required**.

--- a/spdlog/src/test_utils/common.rs
+++ b/spdlog/src/test_utils/common.rs
@@ -220,9 +220,16 @@ pub fn build_test_logger(cb: impl FnOnce(&mut LoggerBuilder) -> &mut LoggerBuild
     builder.build().unwrap()
 }
 
-pub fn assert_send<T: Send>() {}
-
-pub fn assert_sync<T: Sync>() {}
+#[doc(hidden)]
+#[macro_export]
+macro_rules! assert_trait {
+    ($type:ty: $($traits:tt)+) => {{
+        fn __assert_trait<T: $($traits)+>() {}
+        __assert_trait::<$type>();
+    }};
+}
+#[allow(unused_imports)]
+pub use assert_trait;
 
 #[must_use]
 pub fn echo_logger_from_pattern(

--- a/spdlog/tests/compile_fail.rs
+++ b/spdlog/tests/compile_fail.rs
@@ -5,4 +5,6 @@ fn compile_fail() {
     t.compile_fail("tests/compile_fail/pattern_macro_*.rs");
     #[cfg(feature = "runtime-pattern")]
     t.compile_fail("tests/compile_fail/pattern_runtime_macro_*.rs");
+    #[cfg(not(feature = "runtime-pattern"))]
+    t.compile_fail("tests/compile_fail/pattern_runtime_disabled.rs");
 }

--- a/spdlog/tests/compile_fail/pattern_runtime_disabled.rs
+++ b/spdlog/tests/compile_fail/pattern_runtime_disabled.rs
@@ -1,0 +1,7 @@
+use spdlog::formatter::runtime_pattern;
+
+fn runtime_pattern() {
+    runtime_pattern!("{logger}");
+}
+
+fn main() {}

--- a/spdlog/tests/compile_fail/pattern_runtime_disabled.stderr
+++ b/spdlog/tests/compile_fail/pattern_runtime_disabled.stderr
@@ -1,0 +1,7 @@
+error: proc macro panicked
+ --> tests/compile_fail/pattern_runtime_disabled.rs:4:5
+  |
+4 |     runtime_pattern!("{logger}");
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: macro `runtime_pattern` required to enable crate feature `runtime-pattern` for spdlog-rs


### PR DESCRIPTION
Closes #84.

This PR adds checks for all tier 1 and tier 2 targets, with changes:

- Dependency features are now excluded from CI job 'check', because not all dependencies have binary pre-built for all tier 2 targets;

- Errors come from crates other than spdlog-rs are all ignored, because some upstream crates don't support some targets.

Also, I'll try to fix the unsupported targets in the PR latter.