### PR TITLE
Replace `eprintln!` with `writeln!` to avoid broken stdio panic

### DIFF
--- a/spdlog/Cargo.toml
+++ b/spdlog/Cargo.toml
@@ -94,6 +94,9 @@ rustc_version = "0.4.0"
 name = "global_async_pool_sink"
 harness = false
 required-features = ["multi-thread"]
+[[test]]
+name = "broken_stdio"
+harness = false
 
 [[bench]]
 name = "spdlog_rs"

--- a/spdlog/src/lib.rs
+++ b/spdlog/src/lib.rs
@@ -322,7 +322,9 @@ use std::{
     borrow::Cow,
     env::{self, VarError},
     ffi::OsStr,
-    fmt, panic,
+    fmt,
+    io::{self, Write},
+    panic,
     result::Result as StdResult,
 };
 
@@ -769,7 +771,11 @@ fn default_error_handler(from: impl AsRef<str>, error: Error) {
         .format("%Y-%m-%d %H:%M:%S.%3f")
         .to_string();
 
-    eprintln!(
+    // https://github.com/SpriteOvO/spdlog-rs/discussions/87
+    //
+    // Don't use `eprintln!` here, as it may fail to write and then panic.
+    let _ = writeln!(
+        io::stderr(),
         "[*** SPDLOG-RS UNHANDLED ERROR ***] [{}] [{}] {}",
         date,
         from.as_ref(),

--- a/spdlog/tests/broken_stdio.rs
+++ b/spdlog/tests/broken_stdio.rs
@@ -1,0 +1,18 @@
+// https://github.com/SpriteOvO/spdlog-rs/discussions/87
+//
+// Rust's print macros will panic if a write fails, we should avoid using
+// print macros internally.
+fn main() {
+    #[cfg(target_family = "unix")]
+    {
+        let dev_full = std::ffi::CString::new("/dev/full").unwrap();
+        unsafe {
+            let fd = libc::open(dev_full.as_ptr(), libc::O_WRONLY);
+            libc::dup2(fd, libc::STDOUT_FILENO);
+            libc::dup2(fd, libc::STDERR_FILENO);
+        }
+    }
+    // TODO: Other platforms?
+    spdlog::info!("will panic if print macros are used internally");
+    spdlog::error!("will panic if print macros are used internally");
+}


### PR DESCRIPTION
Context #87.

Rust's print macros (`{,e}print{,ln}!`) will panic if a write fails. This PR replaces the only use of `eprintln!` with `writeln!(stderr())` to avoid such potential panic.