### PR TITLE
Implement `get_current_tid_inner` for Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        target: ['', 'x86_64-apple-ios', 'x86_64-unknown-freebsd', 'x86_64-unknown-illumos']
+        target: ['', 'x86_64-apple-ios', 'x86_64-unknown-freebsd', 'x86_64-unknown-illumos', 'aarch64-linux-android']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository

--- a/spdlog/src/record.rs
+++ b/spdlog/src/record.rs
@@ -214,7 +214,7 @@ impl RecordOwned {
 }
 
 fn get_current_tid() -> u64 {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[must_use]
     fn get_current_tid_inner() -> u64 {
         // https://github.com/SpriteOvO/spdlog-rs/issues/31


### PR DESCRIPTION
Someone reported an compilation error on Termux in a Telegram Rust group:

```
error[E0425]: cannot find value get_current_tid_inner in this scope
   --> /data/data/com.termux/files/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/spdlog-rs-0.4.2/src/record.rs:261:57
    |
261 | ...ith(get_current_tid_inner))
    |        ^^^^^^^^^^^^^^^^^^^^^ not found in this
```

This PR adds supports for Android-like OS.