### PR TITLE
Replace spin locks with std locks or parking_lot locks

### DIFF
--- a/spdlog/Cargo.toml
+++ b/spdlog/Cargo.toml
@@ -57,7 +57,6 @@ serde = { version = "1.0.163", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.120", optional = true }
 spdlog-internal = { version = "=0.1.0", path = "../spdlog-internal", optional = true }
 spdlog-macros = { version = "=0.2.0", path = "../spdlog-macros" }
-spin = "0.9.8"
 thiserror = "1.0.37"
 value-bag = { version = "1.11.1", features = ["owned", "inline-i128"] }
 

--- a/spdlog/benches/spdlog-rs/pattern.rs
+++ b/spdlog/benches/spdlog-rs/pattern.rs
@@ -41,6 +41,7 @@ impl<F: Formatter> BenchSink<'_, F> {
 // I think we're just testing benchmarks here, and they should not be executed
 // in parallel, so the data race from `buffer` shouldn't be an problem?
 unsafe impl<F> Sync for BenchSink<'_, F> {}
+unsafe impl<F> Send for BenchSink<'_, F> {}
 
 impl<F: Formatter> Sink for BenchSink<'_, F> {
     fn log(&self, record: &Record) -> spdlog::Result<()> {

--- a/spdlog/src/env_level.rs
+++ b/spdlog/src/env_level.rs
@@ -110,7 +110,7 @@ pub(crate) fn from_str_inner(var: &str) -> Result<EnvLevel, EnvLevelError> {
 
 #[must_use]
 pub(crate) fn logger_level(kind: LoggerKind) -> Option<LevelFilter> {
-    logger_level_inner(ENV_LEVEL.read().unwrap().as_ref()?, kind)
+    logger_level_inner(ENV_LEVEL.read_expect().as_ref()?, kind)
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/spdlog/src/sink/journald_sink.rs
+++ b/spdlog/src/sink/journald_sink.rs
@@ -3,6 +3,7 @@ use std::{io, os::raw::c_int};
 use crate::{
     formatter::{FormatterContext, JournaldFormatter},
     sink::{helper, Sink},
+    sync::RwLockExtend as _,
     Error, Level, Record, Result, StdResult, StringBuf,
 };
 
@@ -120,7 +121,7 @@ impl Sink for JournaldSink {
         let mut ctx = FormatterContext::new();
         self.common_impl
             .formatter
-            .read()
+            .read_expect()
             .format(record, &mut string_buf, &mut ctx)?;
 
         let kvs = [

--- a/spdlog/src/sink/std_stream_sink.rs
+++ b/spdlog/src/sink/std_stream_sink.rs
@@ -10,6 +10,7 @@ use if_chain::if_chain;
 use crate::{
     formatter::FormatterContext,
     sink::{helper, Sink},
+    sync::RwLockExtend as _,
     terminal_style::{LevelStyles, Style, StyleMode},
     Error, Level, Record, Result, StringBuf,
 };
@@ -165,7 +166,7 @@ impl Sink for StdStreamSink {
         let mut ctx = FormatterContext::new();
         self.common_impl
             .formatter
-            .read()
+            .read_expect()
             .format(record, &mut string_buf, &mut ctx)?;
 
         let mut dest = self.dest.lock();

--- a/spdlog/src/sink/win_debug_sink.rs
+++ b/spdlog/src/sink/win_debug_sink.rs
@@ -3,6 +3,7 @@ use std::{ffi::OsStr, iter::once};
 use crate::{
     formatter::FormatterContext,
     sink::{helper, Sink},
+    sync::RwLockExtend as _,
     Record, Result, StringBuf,
 };
 
@@ -52,7 +53,7 @@ impl Sink for WinDebugSink {
         let mut ctx = FormatterContext::new();
         self.common_impl
             .formatter
-            .read()
+            .read_expect()
             .format(record, &mut string_buf, &mut ctx)?;
 
         let wide: Vec<u16> = OsStr::new(&string_buf)

--- a/spdlog/src/sink/write_sink.rs
+++ b/spdlog/src/sink/write_sink.rs
@@ -104,7 +104,7 @@ where
         let mut ctx = FormatterContext::new();
         self.common_impl
             .formatter
-            .read()
+            .read_expect()
             .format(record, &mut string_buf, &mut ctx)?;
 
         self.lock_target()


### PR DESCRIPTION
An article I read a long time ago, which was also mentioned by the author of [_spin_](https://crates.io/crates/spin) crate in the README.

[Spinlocks Considered Harmful](https://matklad.github.io/2020/01/02/spinlocks-considered-harmful.html)

Spin locks may offer some advantages in single-threaded scenarios, but they may not perform all that well in multi-threaded, high CPU contention environments.

I previously chose _spin_ because our benchmarks didn't cover high CPU contention scenarios, and IIRC, a few years ago, _spin_ was indeed better than _std_ locks in single-threaded scenarios. But time has moved on, and things may have changed since then, so I opened this PR as a benchmark experiment to compare _spin_, _std_, and _parking_lot_, to see if it's now worth removing _spin_ or even replacing all locks with _parking_lot_.