### PR TITLE
Replace `write!()` for integers with `write_str` using `numtoa` crate

### DIFF
--- a/spdlog/Cargo.toml
+++ b/spdlog/Cargo.toml
@@ -51,6 +51,7 @@ dyn-clone = "1.0.14"
 flexible-string = { version = "0.1.0", optional = true }
 is-terminal = "0.4"
 log = { version = "0.4.21", optional = true, features = ["kv"] }
+numtoa = { git = "https://github.com/SpriteOvO/numtoa.git", branch = "filling" }
 once_cell = "1.16.0"
 parking_lot = "0.12.0"
 serde = { version = "1.0.163", optional = true, features = ["derive"] }

--- a/spdlog/Cargo.toml
+++ b/spdlog/Cargo.toml
@@ -57,7 +57,7 @@ serde = { version = "1.0.163", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.120", optional = true }
 spdlog-internal = { version = "=0.1.0", path = "../spdlog-internal", optional = true }
 spdlog-macros = { version = "=0.2.0", path = "../spdlog-macros" }
-thiserror = "1.0.37"
+thiserror = "2.0.0"
 value-bag = { version = "1.11.1", features = ["owned", "inline-i128"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/spdlog/src/formatter/android_formatter.rs
+++ b/spdlog/src/formatter/android_formatter.rs
@@ -40,7 +40,7 @@ impl AndroidFormatter {
             dest.write_str(", ")?;
             dest.write_str(srcloc.file())?;
             dest.write_str(":")?;
-            write!(dest, "{}", srcloc.line())?;
+            dest.write_str(&numtoa::BaseN::<10>::u32(srcloc.line()))?;
             dest.write_str("] ")?;
         }
 

--- a/spdlog/src/formatter/full_formatter.rs
+++ b/spdlog/src/formatter/full_formatter.rs
@@ -64,7 +64,10 @@ impl FullFormatter {
                 dest.write_str("[")?;
                 dest.write_str(time.full_second_str())?;
                 dest.write_str(".")?;
-                write!(dest, "{:03}", time.millisecond())?;
+                dest.write_str(&numtoa::BaseN::<10>::u32_filled::<3>(
+                    time.millisecond(),
+                    b'0',
+                ))?;
                 dest.write_str("] [")?;
                 Ok(())
             },
@@ -87,7 +90,7 @@ impl FullFormatter {
             dest.write_str(", ")?;
             dest.write_str(srcloc.file())?;
             dest.write_str(":")?;
-            write!(dest, "{}", srcloc.line())?;
+            dest.write_str(&numtoa::BaseN::<10>::u32(srcloc.line()))?;
         }
 
         dest.write_str("] ")?;

--- a/spdlog/src/formatter/pattern_formatter/pattern/datetime.rs
+++ b/spdlog/src/formatter/pattern_formatter/pattern/datetime.rs
@@ -302,7 +302,11 @@ impl Pattern for Millisecond {
         dest: &mut StringBuf,
         ctx: &mut PatternContext,
     ) -> crate::Result<()> {
-        write!(dest, "{:03}", ctx.time_date().millisecond()).map_err(Error::FormatRecord)
+        dest.write_str(&numtoa::BaseN::<10>::u32_filled::<3>(
+            ctx.time_date().millisecond(),
+            b'0',
+        ))
+        .map_err(Error::FormatRecord)
     }
 }
 
@@ -319,7 +323,9 @@ impl Pattern for Microsecond {
         ctx: &mut PatternContext,
     ) -> crate::Result<()> {
         let nanosecond = ctx.time_date().nanosecond();
-        write!(dest, "{:06}", nanosecond / 1_000).map_err(Error::FormatRecord)
+        let microsecond = nanosecond / 1_000;
+        dest.write_str(&numtoa::BaseN::<10>::u32_filled::<6>(microsecond, b'0'))
+            .map_err(Error::FormatRecord)
     }
 }
 
@@ -335,7 +341,11 @@ impl Pattern for Nanosecond {
         dest: &mut StringBuf,
         ctx: &mut PatternContext,
     ) -> crate::Result<()> {
-        write!(dest, "{:09}", ctx.time_date().nanosecond()).map_err(Error::FormatRecord)
+        dest.write_str(&numtoa::BaseN::<10>::u32_filled::<9>(
+            ctx.time_date().nanosecond(),
+            b'0',
+        ))
+        .map_err(Error::FormatRecord)
     }
 }
 

--- a/spdlog/src/formatter/pattern_formatter/pattern/process_id.rs
+++ b/spdlog/src/formatter/pattern_formatter/pattern/process_id.rs
@@ -26,7 +26,8 @@ impl Pattern for ProcessId {
         _ctx: &mut PatternContext,
     ) -> crate::Result<()> {
         let pid = get_current_process_id();
-        write!(dest, "{pid}").map_err(Error::FormatRecord)
+        dest.write_str(&numtoa::BaseN::<10>::u64(pid))
+            .map_err(Error::FormatRecord)
     }
 }
 

--- a/spdlog/src/formatter/pattern_formatter/pattern/srcloc.rs
+++ b/spdlog/src/formatter/pattern_formatter/pattern/srcloc.rs
@@ -21,7 +21,7 @@ impl Pattern for Source {
             (|| {
                 dest.write_str(loc.file())?;
                 dest.write_char(':')?;
-                write!(dest, "{}", loc.line())
+                dest.write_str(&numtoa::BaseN::<10>::u32(loc.line()))
             })()
             .map_err(Error::FormatRecord)?;
         }
@@ -80,7 +80,8 @@ impl Pattern for SourceLine {
         _ctx: &mut PatternContext,
     ) -> crate::Result<()> {
         if let Some(loc) = record.source_location() {
-            write!(dest, "{}", loc.line()).map_err(Error::FormatRecord)?;
+            dest.write_str(&numtoa::BaseN::<10>::u32(loc.line()))
+                .map_err(Error::FormatRecord)?;
         }
         Ok(())
     }
@@ -98,7 +99,8 @@ impl Pattern for SourceColumn {
         _ctx: &mut PatternContext,
     ) -> crate::Result<()> {
         if let Some(loc) = record.source_location() {
-            write!(dest, "{}", loc.column()).map_err(Error::FormatRecord)?;
+            dest.write_str(&numtoa::BaseN::<10>::u32(loc.column()))
+                .map_err(Error::FormatRecord)?;
         }
         Ok(())
     }

--- a/spdlog/src/formatter/pattern_formatter/pattern/thread_id.rs
+++ b/spdlog/src/formatter/pattern_formatter/pattern/thread_id.rs
@@ -27,6 +27,7 @@ impl Pattern for ThreadId {
         dest: &mut StringBuf,
         _ctx: &mut PatternContext,
     ) -> crate::Result<()> {
-        write!(dest, "{}", record.tid()).map_err(Error::FormatRecord)
+        dest.write_str(&numtoa::BaseN::<10>::u64(record.tid()))
+            .map_err(Error::FormatRecord)
     }
 }

--- a/spdlog/src/lib.rs
+++ b/spdlog/src/lib.rs
@@ -486,6 +486,7 @@ pub fn default_logger() -> Arc<Logger> {
 /// info!("this log will be handled by `new_logger`");
 /// info!(logger: old_logger, "this log will be handled by `old_logger`");
 /// ```
+#[must_use = "the old default logger is returned, if you don't need it, use `set_default_logger` instead"]
 pub fn swap_default_logger(logger: Arc<Logger>) -> Arc<Logger> {
     default_logger_ref().swap(logger)
 }
@@ -504,7 +505,7 @@ pub fn swap_default_logger(logger: Arc<Logger>) -> Arc<Logger> {
 /// info!("this log will be handled by `new_logger`");
 /// ```
 pub fn set_default_logger(logger: Arc<Logger>) {
-    swap_default_logger(logger);
+    _ = swap_default_logger(logger);
 }
 
 /// Initializes environment variable level filters from environment variable


### PR DESCRIPTION
Closes #98.

Since the author of `itoa` decided not to support leading zeros (https://github.com/dtolnay/itoa/issues/61#issuecomment-3341925250), we will only experiment with `numtoa` to see if there is any performance improvement and decide to use it or not.

I will benchmark this PR on a real machine tomorrow.

### Self-reminder

This PR uses the `numtoa` I forked, so merge this after the upstream PR mmstick/numtoa#40 is merged and released.

