### PR TITLE
Add a shorthand method `build_arc` to builder structs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,9 +250,9 @@ jobs:
         journalctl --no-pager -o json -t native_linux | jq -e -s $'.[1].PRIORITY == "3" and .[1].CODE_FILE == null and .[1].CODE_LINE == null and .[1].TID != null'
 
         journalctl --no-pager -o json -t native_linux_srcloc | jq -e -s $'.[0].MESSAGE == "[demo] [info] info message from spdlog-rs\'s JournaldSink\n"'
-        journalctl --no-pager -o json -t native_linux_srcloc | jq -e -s $'.[0].PRIORITY == "6" and .[0].CODE_FILE == "linux.rs" and .[0].CODE_LINE == "15" and .[0].TID != null'
+        journalctl --no-pager -o json -t native_linux_srcloc | jq -e -s $'.[0].PRIORITY == "6" and .[0].CODE_FILE == "linux.rs" and .[0].CODE_LINE != null and .[0].TID != null'
         journalctl --no-pager -o json -t native_linux_srcloc | jq -e -s $'.[1].MESSAGE == "[demo] [error] error message from spdlog-rs\'s JournaldSink { error_code=114514 }\n"'
-        journalctl --no-pager -o json -t native_linux_srcloc | jq -e -s $'.[1].PRIORITY == "3" and .[1].CODE_FILE == "linux.rs" and .[1].CODE_LINE == "16" and .[1].TID != null'
+        journalctl --no-pager -o json -t native_linux_srcloc | jq -e -s $'.[1].PRIORITY == "3" and .[1].CODE_FILE == "linux.rs" and .[1].CODE_LINE != null and .[1].TID != null'
 
   test-native-windows:
     strategy:

--- a/spdlog/benches/spdlog-rs/cmp_cpp.rs
+++ b/spdlog/benches/spdlog-rs/cmp_cpp.rs
@@ -5,7 +5,7 @@ extern crate test;
 #[path = "../common/mod.rs"]
 mod common;
 
-use std::{env, sync::Arc, thread, time::Instant};
+use std::{env, thread, time::Instant};
 
 use clap::Parser;
 use spdlog::{
@@ -36,38 +36,38 @@ fn bench_threaded_logging(threads: usize, iters: usize) {
     info!("**********************************************************************");
 
     let logger = build_test_logger(|b| {
-        b.sink(Arc::new(
+        b.sink(
             FileSink::builder()
                 .path(common::BENCH_LOGS_PATH.join("FileSink.log"))
                 .truncate(true)
-                .build()
+                .build_arc()
                 .unwrap(),
-        ))
+        )
         .name("basic_mt")
     });
     bench_mt(logger, threads, iters);
 
     let logger = build_test_logger(|b| {
-        b.sink(Arc::new(
+        b.sink(
             RotatingFileSink::builder()
                 .base_path(common::BENCH_LOGS_PATH.join("RotatingFileSink_FileSize.log"))
                 .rotation_policy(RotationPolicy::FileSize(FILE_SIZE))
                 .max_files(ROTATING_FILES)
-                .build()
+                .build_arc()
                 .unwrap(),
-        ))
+        )
         .name("rotating_mt")
     });
     bench_mt(logger, threads, iters);
 
     let logger = build_test_logger(|b| {
-        b.sink(Arc::new(
+        b.sink(
             RotatingFileSink::builder()
                 .base_path(common::BENCH_LOGS_PATH.join("RotatingFileSink_Daily.log"))
                 .rotation_policy(RotationPolicy::Daily { hour: 0, minute: 0 })
-                .build()
+                .build_arc()
                 .unwrap(),
-        ))
+        )
         .name("daily_mt")
     });
     bench_mt(logger, threads, iters);

--- a/spdlog/benches/spdlog-rs/cmp_cpp_async.rs
+++ b/spdlog/benches/spdlog-rs/cmp_cpp_async.rs
@@ -5,7 +5,7 @@ extern crate test;
 #[path = "../common/mod.rs"]
 mod common;
 
-use std::{cmp, env, num::NonZeroUsize, sync::Arc, thread, time::Instant};
+use std::{cmp, env, num::NonZeroUsize, thread, time::Instant};
 
 use clap::Parser;
 use spdlog::{
@@ -32,25 +32,24 @@ fn bench(
 
     let queue_size = NonZeroUsize::new(queue_size).unwrap();
     for _ in 0..iters {
-        let thread_pool = Arc::new(ThreadPool::builder().capacity(queue_size).build().unwrap());
+        let thread_pool = ThreadPool::builder()
+            .capacity(queue_size)
+            .build_arc()
+            .unwrap();
 
-        let file_sink = Arc::new(
-            FileSink::builder()
-                .path(common::BENCH_LOGS_PATH.join(file_name))
-                .truncate(true)
-                .build()
-                .unwrap(),
-        );
+        let file_sink = FileSink::builder()
+            .path(common::BENCH_LOGS_PATH.join(file_name))
+            .truncate(true)
+            .build_arc()
+            .unwrap();
 
-        let async_sink = Arc::new(
-            AsyncPoolSink::builder()
-                .thread_pool(thread_pool)
-                .overflow_policy(policy)
-                .sink(file_sink)
-                .error_handler(|err| panic!("an error occurred: {err}"))
-                .build()
-                .unwrap(),
-        );
+        let async_sink = AsyncPoolSink::builder()
+            .thread_pool(thread_pool)
+            .overflow_policy(policy)
+            .sink(file_sink)
+            .error_handler(|err| panic!("an error occurred: {err}"))
+            .build_arc()
+            .unwrap();
 
         let logger = Logger::builder()
             .sink(async_sink)

--- a/spdlog/benches/spdlog-rs/kv.rs
+++ b/spdlog/benches/spdlog-rs/kv.rs
@@ -5,8 +5,6 @@ extern crate test;
 #[path = "../common/mod.rs"]
 mod common;
 
-use std::sync::Arc;
-
 use spdlog::{prelude::*, sink::*};
 use test::Bencher;
 
@@ -18,13 +16,11 @@ use test_utils::*;
 
 fn logger(name: &str) -> Logger {
     let path = common::BENCH_LOGS_PATH.join(format!("kv_{name}.log"));
-    let sink = Arc::new(
-        FileSink::builder()
-            .path(path)
-            .truncate(true)
-            .build()
-            .unwrap(),
-    );
+    let sink = FileSink::builder()
+        .path(path)
+        .truncate(true)
+        .build_arc()
+        .unwrap();
     build_test_logger(|b| b.sink(sink))
 }
 

--- a/spdlog/benches/spdlog-rs/spdlog_rs.rs
+++ b/spdlog/benches/spdlog-rs/spdlog_rs.rs
@@ -39,16 +39,14 @@ impl Mode {
         match self {
             Self::Sync => sink,
             Self::Async => {
-                let thread_pool = Arc::new(ThreadPool::builder().build().unwrap());
+                let thread_pool = ThreadPool::builder().build_arc().unwrap();
 
-                Arc::new(
-                    AsyncPoolSink::builder()
-                        .thread_pool(thread_pool)
-                        .overflow_policy(OverflowPolicy::DropIncoming)
-                        .sink(sink)
-                        .build()
-                        .unwrap(),
-                )
+                AsyncPoolSink::builder()
+                    .thread_pool(thread_pool)
+                    .overflow_policy(OverflowPolicy::DropIncoming)
+                    .sink(sink)
+                    .build_arc()
+                    .unwrap()
             }
         }
     }
@@ -82,31 +80,27 @@ fn bench_any(bencher: &mut Bencher, mode: Mode, sink: Arc<dyn Sink>) {
 }
 
 fn bench_file_inner(bencher: &mut Bencher, mode: Mode) {
-    let sink: Arc<dyn Sink> = Arc::new(
-        FileSink::builder()
-            .path(mode.path("file"))
-            .truncate(true)
-            .build()
-            .unwrap(),
-    );
+    let sink = FileSink::builder()
+        .path(mode.path("file"))
+        .truncate(true)
+        .build_arc()
+        .unwrap();
     bench_any(bencher, mode, sink);
 }
 
 fn bench_rotating_inner(bencher: &mut Bencher, rotation_policy: RotationPolicy) {
-    let sink = Arc::new(
-        RotatingFileSink::builder()
-            .base_path(Mode::Sync.path(match rotation_policy {
-                RotationPolicy::FileSize(_) => "rotating_file_size",
-                RotationPolicy::Daily { .. } => "rotating_daily",
-                RotationPolicy::Hourly => "rotating_hourly",
-                RotationPolicy::Period { .. } => "rotating_period",
-            }))
-            .rotation_policy(rotation_policy)
-            .max_files(common::ROTATING_FILES)
-            .rotate_on_open(true)
-            .build()
-            .unwrap(),
-    );
+    let sink = RotatingFileSink::builder()
+        .base_path(Mode::Sync.path(match rotation_policy {
+            RotationPolicy::FileSize(_) => "rotating_file_size",
+            RotationPolicy::Daily { .. } => "rotating_daily",
+            RotationPolicy::Hourly => "rotating_hourly",
+            RotationPolicy::Period { .. } => "rotating_period",
+        }))
+        .rotation_policy(rotation_policy)
+        .max_files(common::ROTATING_FILES)
+        .rotate_on_open(true)
+        .build_arc()
+        .unwrap();
     bench_any(bencher, Mode::Sync, sink);
 }
 

--- a/spdlog/examples/02_file.rs
+++ b/spdlog/examples/02_file.rs
@@ -1,4 +1,4 @@
-use std::{env, sync::Arc, time::Duration};
+use std::{env, time::Duration};
 
 use spdlog::{
     prelude::*,
@@ -18,8 +18,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn configure_file_logger() -> Result<(), Box<dyn std::error::Error>> {
     let path = env::current_exe()?.with_file_name("file.log");
 
-    let file_sink = Arc::new(FileSink::builder().path(path).build()?);
-    let new_logger = Arc::new(Logger::builder().sink(file_sink).build()?);
+    let file_sink = FileSink::builder().path(path).build_arc()?;
+    let new_logger = Logger::builder().sink(file_sink).build_arc()?;
     spdlog::set_default_logger(new_logger);
 
     info!("this log will be written to the file `all.log`");
@@ -30,13 +30,11 @@ fn configure_file_logger() -> Result<(), Box<dyn std::error::Error>> {
 fn configure_rotating_daily_file_logger() -> Result<(), Box<dyn std::error::Error>> {
     let path = env::current_exe()?.with_file_name("rotating_daily.log");
 
-    let file_sink = Arc::new(
-        RotatingFileSink::builder()
-            .base_path(path)
-            .rotation_policy(RotationPolicy::Daily { hour: 0, minute: 0 })
-            .build()?,
-    );
-    let new_logger = Arc::new(Logger::builder().sink(file_sink).build()?);
+    let file_sink = RotatingFileSink::builder()
+        .base_path(path)
+        .rotation_policy(RotationPolicy::Daily { hour: 0, minute: 0 })
+        .build_arc()?;
+    let new_logger = Logger::builder().sink(file_sink).build_arc()?;
     spdlog::set_default_logger(new_logger);
 
     info!("this log will be written to the file `rotating_daily.log`, and the file will be rotated daily at 00:00");
@@ -47,13 +45,11 @@ fn configure_rotating_daily_file_logger() -> Result<(), Box<dyn std::error::Erro
 fn configure_rotating_size_file_logger() -> Result<(), Box<dyn std::error::Error>> {
     let path = env::current_exe()?.with_file_name("rotating_size.log");
 
-    let file_sink = Arc::new(
-        RotatingFileSink::builder()
-            .base_path(path)
-            .rotation_policy(RotationPolicy::FileSize(1024))
-            .build()?,
-    );
-    let new_logger = Arc::new(Logger::builder().sink(file_sink).build()?);
+    let file_sink = RotatingFileSink::builder()
+        .base_path(path)
+        .rotation_policy(RotationPolicy::FileSize(1024))
+        .build_arc()?;
+    let new_logger = Logger::builder().sink(file_sink).build_arc()?;
     spdlog::set_default_logger(new_logger);
 
     info!("this log will be written to the file `rotating_size.log`, and the file will be rotated when its size reaches 1024 bytes");
@@ -64,13 +60,11 @@ fn configure_rotating_size_file_logger() -> Result<(), Box<dyn std::error::Error
 fn configure_rotating_hourly_file_logger() -> Result<(), Box<dyn std::error::Error>> {
     let path = env::current_exe()?.with_file_name("rotating_hourly.log");
 
-    let file_sink = Arc::new(
-        RotatingFileSink::builder()
-            .base_path(path)
-            .rotation_policy(RotationPolicy::Hourly)
-            .build()?,
-    );
-    let new_logger = Arc::new(Logger::builder().sink(file_sink).build()?);
+    let file_sink = RotatingFileSink::builder()
+        .base_path(path)
+        .rotation_policy(RotationPolicy::Hourly)
+        .build_arc()?;
+    let new_logger = Logger::builder().sink(file_sink).build_arc()?;
     spdlog::set_default_logger(new_logger);
 
     info!("this log will be written to the file `rotating_hourly.log`, and the file will be rotated every hour");
@@ -81,15 +75,13 @@ fn configure_rotating_hourly_file_logger() -> Result<(), Box<dyn std::error::Err
 fn configure_rotating_period_file_logger() -> Result<(), Box<dyn std::error::Error>> {
     let path = env::current_exe()?.with_file_name("rotating_period.log");
 
-    let file_sink = Arc::new(
-        RotatingFileSink::builder()
-            .base_path(path)
-            .rotation_policy(RotationPolicy::Period(Duration::from_secs(
-                60 * 90, // 90 minutes
-            )))
-            .build()?,
-    );
-    let new_logger = Arc::new(Logger::builder().sink(file_sink).build()?);
+    let file_sink = RotatingFileSink::builder()
+        .base_path(path)
+        .rotation_policy(RotationPolicy::Period(Duration::from_secs(
+            60 * 90, // 90 minutes
+        )))
+        .build_arc()?;
+    let new_logger = Logger::builder().sink(file_sink).build_arc()?;
     spdlog::set_default_logger(new_logger);
 
     info!("this log will be written to the file `rotating_period.log`, and the file will be rotated every 1.5 hours");

--- a/spdlog/examples/03_logger.rs
+++ b/spdlog/examples/03_logger.rs
@@ -13,15 +13,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Or completely replace it with a new one.
     let path = env::current_exe()?.with_file_name("all.log");
-    let file_sink = Arc::new(FileSink::builder().path(path).build()?);
+    let file_sink = FileSink::builder().path(path).build_arc()?;
 
-    let new_logger = Arc::new(
-        Logger::builder()
-            .level_filter(LevelFilter::All)
-            .flush_level_filter(LevelFilter::MoreSevereEqual(Level::Warn))
-            .sink(file_sink.clone())
-            .build()?,
-    );
+    let new_logger = Logger::builder()
+        .level_filter(LevelFilter::All)
+        .flush_level_filter(LevelFilter::MoreSevereEqual(Level::Warn))
+        .sink(file_sink.clone())
+        .build_arc()?;
     new_logger.set_flush_period(Some(Duration::from_secs(3)));
     spdlog::set_default_logger(new_logger);
 
@@ -42,7 +40,7 @@ struct AppDatabase {
 impl AppDatabase {
     fn new(all_log_sink: Arc<dyn Sink>) -> Result<Self, Box<dyn std::error::Error>> {
         let path = env::current_exe()?.with_file_name("db.log");
-        let db_file_sink = Arc::new(FileSink::builder().path(path).build()?);
+        let db_file_sink = FileSink::builder().path(path).build_arc()?;
 
         let logger = Logger::builder()
             .name("database")

--- a/spdlog/examples/07_async.rs
+++ b/spdlog/examples/07_async.rs
@@ -1,4 +1,4 @@
-use std::{env, sync::Arc};
+use std::env;
 
 use spdlog::{
     prelude::*,
@@ -7,17 +7,15 @@ use spdlog::{
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = env::current_exe()?.with_file_name("async.log");
-    let file_sink = Arc::new(FileSink::builder().path(path).build()?);
+    let file_sink = FileSink::builder().path(path).build_arc()?;
 
     // AsyncPoolSink is a combined sink which wraps other sinks
-    let async_pool_sink = Arc::new(AsyncPoolSink::builder().sink(file_sink).build()?);
+    let async_pool_sink = AsyncPoolSink::builder().sink(file_sink).build_arc()?;
 
-    let async_logger = Arc::new(
-        Logger::builder()
-            .sink(async_pool_sink)
-            .flush_level_filter(LevelFilter::All)
-            .build()?,
-    );
+    let async_logger = Logger::builder()
+        .sink(async_pool_sink)
+        .flush_level_filter(LevelFilter::All)
+        .build_arc()?;
 
     info!(logger: async_logger, "Hello, async!");
 

--- a/spdlog/examples/native/android.rs
+++ b/spdlog/examples/native/android.rs
@@ -1,17 +1,13 @@
 #[cfg(target_os = "android")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use std::sync::Arc;
-
     use spdlog::{
         prelude::*,
         sink::{AndroidLogTag, AndroidSink},
     };
 
-    let sink = Arc::new(
-        AndroidSink::builder()
-            .tag(AndroidLogTag::Custom("spdlog-rs-example".into()))
-            .build()?,
-    );
+    let sink = AndroidSink::builder()
+        .tag(AndroidLogTag::Custom("spdlog-rs-example".into()))
+        .build_arc()?;
     let logger = spdlog::default_logger().fork_with(|logger| {
         logger.set_name(Some("demo")).unwrap();
         logger.sinks_mut().push(sink);

--- a/spdlog/examples/native/linux.rs
+++ b/spdlog/examples/native/linux.rs
@@ -1,10 +1,8 @@
 #[cfg(target_os = "linux")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use std::sync::Arc;
-
     use spdlog::{prelude::*, sink::JournaldSink};
 
-    let sink = Arc::new(JournaldSink::builder().build()?);
+    let sink = JournaldSink::builder().build_arc()?;
     let logger = spdlog::default_logger().fork_with(|logger| {
         logger.set_name(Some("demo")).unwrap();
         logger.sinks_mut().push(sink);

--- a/spdlog/examples/native/windows.rs
+++ b/spdlog/examples/native/windows.rs
@@ -1,10 +1,8 @@
 #[cfg(target_os = "windows")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use std::sync::Arc;
-
     use spdlog::{prelude::*, sink::WinDebugSink};
 
-    let sink = Arc::new(WinDebugSink::builder().build()?);
+    let sink = WinDebugSink::builder().build_arc()?;
     let logger = spdlog::default_logger().fork_with(|logger| {
         logger.set_name(Some("demo")).unwrap();
         logger.sinks_mut().push(sink);

--- a/spdlog/src/lib.rs
+++ b/spdlog/src/lib.rs
@@ -69,7 +69,6 @@
 //! want logs to be written to files as well, [`FileSink`] is what you need.
 //!
 //! ```
-//! # use std::sync::Arc;
 //! use spdlog::{prelude::*, sink::FileSink};
 //!
 //! # fn main() -> spdlog::Result<()> {
@@ -77,7 +76,7 @@
 //!
 //! # let path = concat!(env!("OUT_DIR"), "/doctest-out/crate-1.txt");
 //! let new_logger = spdlog::default_logger().fork_with(|new| {
-//!     let file_sink = Arc::new(FileSink::builder().path(path).build()?);
+//!     let file_sink = FileSink::builder().path(path).build_arc()?;
 //!     new.sinks_mut().push(file_sink);
 //!     Ok(())
 //! })?;
@@ -414,16 +413,16 @@ fn default_logger_ref() -> &'static ArcSwap<Logger> {
         let stdout = StdStreamSink::builder()
             .stdout()
             .level_filter(LevelFilter::MoreVerbose(Level::Warn))
-            .build()
+            .build_arc()
             .unwrap();
 
         let stderr = StdStreamSink::builder()
             .stderr()
             .level_filter(LevelFilter::MoreSevereEqual(Level::Warn))
-            .build()
+            .build_arc()
             .unwrap();
 
-        let sinks: [Arc<dyn Sink>; 2] = [Arc::new(stdout), Arc::new(stderr)];
+        let sinks: [Arc<dyn Sink>; 2] = [stdout, stderr];
 
         let res = ArcSwap::from_pointee(Logger::builder().sinks(sinks).build_default().unwrap());
 
@@ -809,7 +808,7 @@ mod tests {
         let test_sink = Arc::new(TestSink::new());
 
         let test_logger = Arc::new(build_test_logger(|b| b.sink(test_sink.clone())));
-        let empty_logger = Arc::new(Logger::builder().build().unwrap());
+        let empty_logger = Logger::builder().build_arc().unwrap();
 
         set_default_logger(empty_logger.clone());
         info!("hello");

--- a/spdlog/src/sink/android_sink.rs
+++ b/spdlog/src/sink/android_sink.rs
@@ -6,6 +6,7 @@ use crate::{
     formatter::{AndroidFormatter, Formatter, FormatterContext},
     prelude::*,
     sink::{GetSinkProp, Sink, SinkProp},
+    sync::*,
     Error, ErrorHandler, Record, Result, StringBuf,
 };
 
@@ -166,6 +167,13 @@ impl AndroidSinkBuilder {
             prop: self.prop,
             tag: self.tag,
         })
+    }
+
+    /// Builds a `Arc<AndroidSink>`.
+    ///
+    /// This is a shorthand method for `.build().map(Arc::new)`.
+    pub fn build_arc(self) -> Result<Arc<AndroidSink>> {
+        self.build().map(Arc::new)
     }
 }
 

--- a/spdlog/src/sink/async_sink/async_pool_sink.rs
+++ b/spdlog/src/sink/async_sink/async_pool_sink.rs
@@ -242,6 +242,13 @@ impl AsyncPoolSinkBuilder {
             backend,
         })
     }
+
+    /// Builds a `Arc<AsyncPoolSink>`.
+    ///
+    /// This is a shorthand method for `.build().map(Arc::new)`.
+    pub fn build_arc(self) -> Result<Arc<AsyncPoolSink>> {
+        self.build().map(Arc::new)
+    }
 }
 
 pub(crate) struct Backend {
@@ -319,12 +326,12 @@ mod tests {
         let counter_sink = Arc::new(TestSink::new());
         let build_logger = || {
             build_test_logger(|b| {
-                b.sink(Arc::new(
+                b.sink(
                     AsyncPoolSink::builder()
                         .sink(counter_sink.clone())
-                        .build()
+                        .build_arc()
                         .unwrap(),
-                ))
+                )
                 .level_filter(LevelFilter::All)
                 .flush_level_filter(LevelFilter::MoreSevereEqual(Level::Error))
             })
@@ -365,15 +372,15 @@ mod tests {
     #[test]
     fn custom_thread_pool() {
         let counter_sink = Arc::new(TestSink::new());
-        let thread_pool = Arc::new(ThreadPool::builder().build().unwrap());
+        let thread_pool = ThreadPool::builder().build_arc().unwrap();
         let logger = build_test_logger(|b| {
-            b.sink(Arc::new(
+            b.sink(
                 AsyncPoolSink::builder()
                     .sink(counter_sink.clone())
                     .thread_pool(thread_pool)
-                    .build()
+                    .build_arc()
                     .unwrap(),
-            ))
+            )
             .level_filter(LevelFilter::All)
             .flush_level_filter(LevelFilter::MoreSevereEqual(Level::Error))
         });
@@ -402,15 +409,15 @@ mod tests {
         let counter_sink = Arc::new(TestSink::with_delay(Some(Duration::from_secs(1))));
         // The default thread pool is not used here to avoid race when tests are run in
         // parallel.
-        let thread_pool = Arc::new(ThreadPool::builder().build().unwrap());
+        let thread_pool = ThreadPool::builder().build_arc().unwrap();
         let logger = build_test_logger(|b| {
-            b.sink(Arc::new(
+            b.sink(
                 AsyncPoolSink::builder()
                     .sink(counter_sink.clone())
                     .thread_pool(thread_pool)
-                    .build()
+                    .build_arc()
                     .unwrap(),
-            ))
+            )
             .level_filter(LevelFilter::All)
             .flush_level_filter(LevelFilter::MoreSevereEqual(Level::Warn))
         });

--- a/spdlog/src/sink/dedup_sink.rs
+++ b/spdlog/src/sink/dedup_sink.rs
@@ -29,28 +29,23 @@ struct DedupSinkState {
 /// use std::time::Duration;
 ///
 /// use spdlog::{prelude::*, sink::DedupSink};
-/// # use std::sync::Arc;
 /// # use spdlog::{
 /// #     formatter::{pattern, PatternFormatter},
 /// #     sink::WriteSink,
 /// # };
 /// #
 /// # fn main() -> Result<(), spdlog::Error> {
-/// # let underlying_sink = Arc::new(
-/// #     WriteSink::builder()
-/// #         .formatter(PatternFormatter::new(pattern!("{payload}\n")))
-/// #         .target(Vec::new())
-/// #         .build()?
-/// # );
+/// # let underlying_sink = WriteSink::builder()
+/// #     .formatter(PatternFormatter::new(pattern!("{payload}\n")))
+/// #     .target(Vec::new())
+/// #     .build_arc()?;
 ///
 /// # let sink = {
 /// #     let underlying_sink = underlying_sink.clone();
-/// let sink = Arc::new(
-///     DedupSink::builder()
-///         .sink(underlying_sink)
-///         .skip_duration(Duration::from_secs(1))
-///         .build()?
-/// );
+/// let sink = DedupSink::builder()
+///     .sink(underlying_sink)
+///     .skip_duration(Duration::from_secs(1))
+///     .build_arc()?;
 /// #     sink
 /// # };
 /// # let doctest = Logger::builder().sink(sink).build()?;
@@ -291,6 +286,13 @@ impl DedupSinkBuilder<()> {
         - missing required parameter `skip_duration`\n\n\
     ")]
     pub fn build(self, _: Infallible) {}
+
+    #[doc(hidden)]
+    #[deprecated(note = "\n\n\
+        builder compile-time error:\n\
+        - missing required parameter `skip_duration`\n\n\
+    ")]
+    pub fn build_arc(self, _: Infallible) {}
 }
 
 impl DedupSinkBuilder<Duration> {
@@ -306,6 +308,13 @@ impl DedupSinkBuilder<Duration> {
             }),
         })
     }
+
+    /// Builds a `Arc<DedupSink>`.
+    ///
+    /// This is a shorthand method for `.build().map(Arc::new)`.
+    pub fn build_arc(self) -> Result<Arc<DedupSink>> {
+        self.build().map(Arc::new)
+    }
 }
 
 #[cfg(test)]
@@ -318,13 +327,11 @@ mod tests {
     #[test]
     fn dedup() {
         let test_sink = Arc::new(TestSink::new());
-        let dedup_sink = Arc::new(
-            DedupSink::builder()
-                .skip_duration(Duration::from_secs(1))
-                .sink(test_sink.clone())
-                .build()
-                .unwrap(),
-        );
+        let dedup_sink = DedupSink::builder()
+            .skip_duration(Duration::from_secs(1))
+            .sink(test_sink.clone())
+            .build_arc()
+            .unwrap();
         let test = build_test_logger(|b| b.sink(dedup_sink));
 
         info!(logger: test, "I wish I was a cat");
@@ -400,13 +407,11 @@ mod tests {
             let records = {
                 let test_sink = Arc::new(TestSink::new());
                 {
-                    let dedup_sink = Arc::new(
-                        DedupSink::builder()
-                            .skip_duration(Duration::from_secs(1))
-                            .sink(test_sink.clone())
-                            .build()
-                            .unwrap(),
-                    );
+                    let dedup_sink = DedupSink::builder()
+                        .skip_duration(Duration::from_secs(1))
+                        .sink(test_sink.clone())
+                        .build_arc()
+                        .unwrap();
                     let test = build_test_logger(|b| b.sink(dedup_sink));
 
                     info!(logger: test, "I wish I was a cat");
@@ -428,13 +433,11 @@ mod tests {
             let records = {
                 let test_sink = Arc::new(TestSink::new());
                 {
-                    let dedup_sink = Arc::new(
-                        DedupSink::builder()
-                            .skip_duration(Duration::from_secs(1))
-                            .sink(test_sink.clone())
-                            .build()
-                            .unwrap(),
-                    );
+                    let dedup_sink = DedupSink::builder()
+                        .skip_duration(Duration::from_secs(1))
+                        .sink(test_sink.clone())
+                        .build_arc()
+                        .unwrap();
                     let test = build_test_logger(|b| b.sink(dedup_sink));
 
                     info!(logger: test, "I wish I was a cat");

--- a/spdlog/src/sink/file_sink.rs
+++ b/spdlog/src/sink/file_sink.rs
@@ -212,6 +212,13 @@ impl FileSinkBuilder<()> {
         - missing required parameter `path`\n\n\
     ")]
     pub fn build(self, _: Infallible) {}
+
+    #[doc(hidden)]
+    #[deprecated(note = "\n\n\
+        builder compile-time error:\n\
+        - missing required parameter `path`\n\n\
+    ")]
+    pub fn build_arc(self, _: Infallible) {}
 }
 
 impl FileSinkBuilder<PathBuf> {
@@ -230,5 +237,12 @@ impl FileSinkBuilder<PathBuf> {
         };
 
         Ok(sink)
+    }
+
+    /// Builds a `Arc<FileSink>`.
+    ///
+    /// This is a shorthand method for `.build().map(Arc::new)`.
+    pub fn build_arc(self) -> Result<Arc<FileSink>> {
+        self.build().map(Arc::new)
     }
 }

--- a/spdlog/src/sink/journald_sink.rs
+++ b/spdlog/src/sink/journald_sink.rs
@@ -3,6 +3,7 @@ use std::{io, os::raw::c_int};
 use crate::{
     formatter::{Formatter, FormatterContext, JournaldFormatter},
     sink::{GetSinkProp, Sink, SinkProp},
+    sync::*,
     Error, ErrorHandler, Level, LevelFilter, Record, Result, StdResult, StringBuf,
 };
 
@@ -199,5 +200,12 @@ impl JournaldSinkBuilder {
     pub fn build(self) -> Result<JournaldSink> {
         let sink = JournaldSink { prop: self.prop };
         Ok(sink)
+    }
+
+    /// Builds a `Arc<JournaldSink>`.
+    ///
+    /// This is a shorthand method for `.build().map(Arc::new)`.
+    pub fn build_arc(self) -> Result<Arc<JournaldSink>> {
+        self.build().map(Arc::new)
     }
 }

--- a/spdlog/src/sink/std_stream_sink.rs
+++ b/spdlog/src/sink/std_stream_sink.rs
@@ -8,6 +8,7 @@ use std::{
 use crate::{
     formatter::{Formatter, FormatterContext},
     sink::{GetSinkProp, Sink, SinkProp},
+    sync::*,
     terminal_style::{LevelStyles, Style, StyleMode},
     Error, ErrorHandler, Level, LevelFilter, Record, Result, StringBuf,
 };
@@ -298,6 +299,13 @@ impl StdStreamSinkBuilder<()> {
         - missing required parameter `std_stream`\n\n\
     ")]
     pub fn build(self, _: Infallible) {}
+
+    #[doc(hidden)]
+    #[deprecated(note = "\n\n\
+        builder compile-time error:\n\
+        - missing required parameter `std_stream`\n\n\
+    ")]
+    pub fn build_arc(self, _: Infallible) {}
 }
 
 impl StdStreamSinkBuilder<StdStream> {
@@ -312,6 +320,13 @@ impl StdStreamSinkBuilder<StdStream> {
             ),
             level_styles: LevelStyles::default(),
         })
+    }
+
+    /// Builds a `Arc<StdStreamSink>`.
+    ///
+    /// This is a shorthand method for `.build().map(Arc::new)`.
+    pub fn build_arc(self) -> Result<Arc<StdStreamSink>> {
+        self.build().map(Arc::new)
     }
 }
 

--- a/spdlog/src/sink/win_debug_sink.rs
+++ b/spdlog/src/sink/win_debug_sink.rs
@@ -3,6 +3,7 @@ use std::{ffi::OsStr, iter::once};
 use crate::{
     formatter::{Formatter, FormatterContext},
     sink::{GetSinkProp, Sink, SinkProp},
+    sync::*,
     ErrorHandler, LevelFilter, Record, Result, StringBuf,
 };
 
@@ -121,5 +122,12 @@ impl WinDebugSinkBuilder {
     pub fn build(self) -> Result<WinDebugSink> {
         let sink = WinDebugSink { prop: self.prop };
         Ok(sink)
+    }
+
+    /// Builds a `Arc<WinDebugSink>`.
+    ///
+    /// This is a shorthand method for `.build().map(Arc::new)`.
+    pub fn build_arc(self) -> Result<Arc<WinDebugSink>> {
+        self.build().map(Arc::new)
     }
 }

--- a/spdlog/src/sink/write_sink.rs
+++ b/spdlog/src/sink/write_sink.rs
@@ -208,6 +208,13 @@ where
         - missing required parameter `target`\n\n\
     ")]
     pub fn build(self, _: Infallible) {}
+
+    #[doc(hidden)]
+    #[deprecated(note = "\n\n\
+        builder compile-time error:\n\
+        - missing required parameter `target`\n\n\
+    ")]
+    pub fn build_arc(self, _: Infallible) {}
 }
 
 impl<W> WriteSinkBuilder<W, PhantomData<W>>
@@ -222,6 +229,13 @@ where
         };
         Ok(sink)
     }
+
+    /// Builds a `Arc<WriteSink>`.
+    ///
+    /// This is a shorthand method for `.build().map(Arc::new)`.
+    pub fn build_arc(self) -> Result<Arc<WriteSink<W>>> {
+        self.build().map(Arc::new)
+    }
 }
 
 #[cfg(test)]
@@ -231,7 +245,7 @@ mod tests {
 
     #[test]
     fn validation() {
-        let sink = Arc::new(WriteSink::builder().target(Vec::new()).build().unwrap());
+        let sink = WriteSink::builder().target(Vec::new()).build_arc().unwrap();
         sink.set_formatter(Box::new(NoModFormatter::new()));
         let logger = build_test_logger(|b| b.sink(sink.clone()).level_filter(LevelFilter::All));
 

--- a/spdlog/src/thread_pool.rs
+++ b/spdlog/src/thread_pool.rs
@@ -194,6 +194,13 @@ impl ThreadPoolBuilder {
             },
         )))))
     }
+
+    /// Builds a `Arc<ThreadPool>`.
+    ///
+    /// This is a shorthand method for `.build().map(Arc::new)`.
+    pub fn build_arc(&self) -> Result<Arc<ThreadPool>> {
+        self.build().map(Arc::new)
+    }
 }
 
 impl Worker {
@@ -213,7 +220,7 @@ pub(crate) fn default_thread_pool() -> Arc<ThreadPool> {
     match pool_weak.upgrade() {
         Some(pool) => pool,
         None => {
-            let pool = Arc::new(ThreadPool::builder().build().unwrap());
+            let pool = ThreadPool::builder().build_arc().unwrap();
             *pool_weak = Arc::downgrade(&pool);
             pool
         }

--- a/spdlog/tests/global_async_pool_sink.rs
+++ b/spdlog/tests/global_async_pool_sink.rs
@@ -55,20 +55,16 @@ fn run_test() {
         }
         assert_eq!(unsafe { atexit(check) }, 0);
 
-        let async_pool_sink = Arc::new(
-            AsyncPoolSink::builder()
-                .sink(Arc::new(SetFlagSink::default()))
-                .build()
-                .unwrap(),
-        );
-        let logger = Arc::new(
-            Logger::builder()
-                .sink(async_pool_sink)
-                .level_filter(LevelFilter::All)
-                .flush_level_filter(LevelFilter::Off)
-                .build()
-                .unwrap(),
-        );
+        let async_pool_sink = AsyncPoolSink::builder()
+            .sink(Arc::new(SetFlagSink::default()))
+            .build_arc()
+            .unwrap();
+        let logger = Logger::builder()
+            .sink(async_pool_sink)
+            .level_filter(LevelFilter::All)
+            .flush_level_filter(LevelFilter::Off)
+            .build_arc()
+            .unwrap();
         spdlog::set_default_logger(logger);
     }
 

--- a/spdlog/tests/pattern.rs
+++ b/spdlog/tests/pattern.rs
@@ -520,19 +520,17 @@ fn test_different_context_thread() {
     use spdlog::{sink::AsyncPoolSink, ThreadPool};
 
     let formatter = PatternFormatter::new(pattern!("{tid}{eol}"));
-    let thread_pool = Arc::new(ThreadPool::builder().build().unwrap());
+    let thread_pool = ThreadPool::builder().build_arc().unwrap();
     let buffer_sink = Arc::new(test_utils::StringSink::with(|b| b.formatter(formatter)));
     let sinks: [Arc<dyn Sink>; 2] = [
         buffer_sink.clone(),
-        Arc::new(
-            AsyncPoolSink::builder()
-                .sink(buffer_sink.clone())
-                .thread_pool(thread_pool)
-                .build()
-                .unwrap(),
-        ),
+        AsyncPoolSink::builder()
+            .sink(buffer_sink.clone())
+            .thread_pool(thread_pool)
+            .build_arc()
+            .unwrap(),
     ];
-    let logger = Arc::new(Logger::builder().sinks(sinks).build().unwrap());
+    let logger = Logger::builder().sinks(sinks).build_arc().unwrap();
 
     info!(logger: logger, "");
     std::thread::sleep(Duration::from_millis(200));


### PR DESCRIPTION
Simplify usage.

### Before

```rust
use std::sync::Arc;

let file_sink = Arc::new(
    RotatingFileSink::builder()
        .base_path(path)
        .rotation_policy(RotationPolicy::Daily { hour: 0, minute: 0 })
        .build()?,
);
let new_logger = Arc::new(Logger::builder().sink(file_sink).build()?);
spdlog::set_default_logger(new_logger);
```

### After

```rust
let file_sink = RotatingFileSink::builder()
    .base_path(path)
    .rotation_policy(RotationPolicy::Daily { hour: 0, minute: 0 })
    .build_arc()?;
let new_logger = Logger::builder().sink(file_sink).build_arc()?;
spdlog::set_default_logger(new_logger);
```